### PR TITLE
[Editor] Added FontSize zoom action with Ctrl + and Ctrl -.

### DIFF
--- a/AvalonStudio/AvalonStudio.TextEditor/Rendering/TextView.cs
+++ b/AvalonStudio/AvalonStudio.TextEditor/Rendering/TextView.cs
@@ -86,6 +86,8 @@
             disposables.Add(FontSizeProperty.Changed.Subscribe((o) =>
             {
                 GenerateTextProperties();
+
+                Invalidate();
             }));
 
             disposables.Add(FontFamilyProperty.Changed.Subscribe((o) =>
@@ -563,7 +565,7 @@
         #endregion
 
         #region Private Methods
-        private void GenerateTextProperties()
+        public void GenerateTextProperties()
         {
             using (var formattedText = new FormattedText("x", FontFamily, FontSize, FontStyle.Normal, TextAlignment.Left, FontWeight.Normal))
             {

--- a/AvalonStudio/AvalonStudio.TextEditor/TextEditor.cs
+++ b/AvalonStudio/AvalonStudio.TextEditor/TextEditor.cs
@@ -850,6 +850,26 @@
 
             switch (e.Key)
             {
+                case Key.OemPlus:
+                    if (modifiers == InputModifiers.Control)
+                    {
+                        if (textView.FontSize < 60)
+                        {
+                            textView.FontSize++;
+                        }
+                    }
+                    break;
+
+                case Key.OemMinus:
+                    if (modifiers == InputModifiers.Control)
+                    {
+                        if (textView.FontSize > 1)
+                        {
+                            textView.FontSize--;
+                        }
+                    }
+                    break;
+
                 case Key.A:
                     if (modifiers == InputModifiers.Control)
                     {


### PR DESCRIPTION
Effect looks really nice, but maybe we can extend this to scale all elements in the Editor component. (I.e. code completion etc). Would be nice for code demo's in presentations etc.