### PR TITLE
(ui tweak) allow easy toggling of system decorations

### DIFF
--- a/AvalonStudio/AvalonStudio/Controls/MetroWindow.cs
+++ b/AvalonStudio/AvalonStudio/Controls/MetroWindow.cs
@@ -122,7 +122,35 @@ namespace AvalonStudio.Controls
 			}
 		}
 
-		protected override void OnTemplateApplied(TemplateAppliedEventArgs e)
+        public void EnableSystemStyles()
+        {
+            HasSystemDecorations = true;
+            closeButton.Opacity = 0;
+            minimiseButton.Opacity = 0;
+            restoreButton.Opacity = 0;
+        }
+        
+        public void DisableSystemStyles()
+        {
+            HasSystemDecorations = false;
+            closeButton.Opacity = 1;
+            minimiseButton.Opacity = 1;
+            restoreButton.Opacity = 1;
+        }
+
+        public void ToggleSystemStyles()
+        {
+            if (HasSystemDecorations)
+            {
+                DisableSystemStyles();
+            }
+            else
+            {
+                EnableSystemStyles();
+            }
+        }
+
+        protected override void OnTemplateApplied(TemplateAppliedEventArgs e)
 		{
 			titleBar = e.NameScope.Find<Grid>("titlebar");
 			minimiseButton = e.NameScope.Find<Button>("minimiseButton");
@@ -149,6 +177,8 @@ namespace AvalonStudio.Controls
 			closeButton.Click += (sender, ee) => { Application.Current.Exit(); };
 
 			icon.DoubleTapped += (sender, ee) => { Close(); };
+
+            icon.Tapped += (sender, ee) => { ToggleSystemStyles(); };
 		}
 	}
 }


### PR DESCRIPTION
clicking the (always gray) icon button now toggles system decorations. i thought this might come in handy until screen dimension detection is added to Avalonia. double clicking still closes the window.