### PR TITLE
dont provision settings when project is loaded, as this pollutes project

### DIFF
--- a/AvalonStudio/AvalonStudio.Extensibility/Projects/Solution.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Projects/Solution.cs
@@ -149,7 +149,6 @@ namespace AvalonStudio.Projects
 			foreach (var project in solution.Projects)
 			{
 				project.ResolveReferences();
-                project?.ToolChain?.ProvisionSettings(project);
             }
 
 			solution.Name = Path.GetFileNameWithoutExtension(fileName);

--- a/AvalonStudio/AvalonStudio.Toolchains.Standard/StandardToolChain.cs
+++ b/AvalonStudio/AvalonStudio.Toolchains.Standard/StandardToolChain.cs
@@ -382,9 +382,14 @@ namespace AvalonStudio.Toolchains.Standard
 		private async Task CompileProject(IConsole console, IStandardProject superProject, IStandardProject project,
 			List<CompileResult> results = null)
 		{
+            if(project == superProject)
+            {
+                superProject.ToolChain?.ProvisionSettings(project);
+            }
+
 			if (project.Type == ProjectType.Executable && superProject != project)
 			{
-				await Build(console, project);
+                await Build(console, project);
 			}
 			else
 			{


### PR DESCRIPTION
files unnecesarily.