### PR TITLE
WIP: Finish Debugging Upgrade

### DIFF
--- a/AvalonStudio/AvalonStudio.Controls.Standard/AvalonStudio.Controls.Standard.csproj
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/AvalonStudio.Controls.Standard.csproj
@@ -3,7 +3,7 @@
     <OutputType>library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
     <PostBuildEvent>
     </PostBuildEvent>
   </PropertyGroup>

--- a/AvalonStudio/AvalonStudio.Controls.Standard/WelcomeScreen/RecentProjectViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/WelcomeScreen/RecentProjectViewModel.cs
@@ -11,8 +11,8 @@ namespace AvalonStudio.Controls.Standard.WelcomeScreen
     {
         public RecentProjectViewModel(string name, string location)
         {
-            this._name = name;
-            this._location = location;
+            _name = name;
+            _location = location;
 
             ClickCommand = ReactiveCommand.Create();
 
@@ -20,9 +20,7 @@ namespace AvalonStudio.Controls.Standard.WelcomeScreen
             {
                 var shell = IoC.Get<IShell>();
 
-                var path = Path.Combine(location, name + ".asln");
-
-                shell.OpenSolutionAsync(path);
+                shell.OpenSolutionAsync(_location);
             });
         }
 

--- a/AvalonStudio/AvalonStudio.Controls.Standard/WelcomeScreen/RecentProjectsCollection.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/WelcomeScreen/RecentProjectsCollection.cs
@@ -42,11 +42,18 @@
 
         public static void Deserialize()
         {
-            try
+            if (File.Exists(_savePath))
             {
-                _recentProjects = SerializedObject.Deserialize<List<RecentProject>>(_savePath);
+                try
+                {
+                    _recentProjects = SerializedObject.Deserialize<List<RecentProject>>(_savePath);
+                }
+                catch (Exception)
+                {
+                    _recentProjects = new List<RecentProject>();
+                }
             }
-            catch (Exception)
+            else
             {
                 _recentProjects = new List<RecentProject>();
             }

--- a/AvalonStudio/AvalonStudio.Controls.Standard/WelcomeScreen/WelcomeScreenViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/WelcomeScreen/WelcomeScreenViewModel.cs
@@ -181,7 +181,7 @@
                 var newProject = new RecentProject
                 {
                     Name = e.NewValue.Name,
-                    Path = e.NewValue.CurrentDirectory
+                    Path = e.NewValue.Location
                 };
 
                 if (RecentProjectsCollection.RecentProjects == null)

--- a/AvalonStudio/AvalonStudio.Debugging.GDB.JLink/AvalonStudio.Debugging.GDB.JLink.csproj
+++ b/AvalonStudio/AvalonStudio.Debugging.GDB.JLink/AvalonStudio.Debugging.GDB.JLink.csproj
@@ -14,5 +14,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\AvalonStudio.Debugging.GDB\AvalonStudio.Debugging.GDB.csproj" />
+    <ProjectReference Include="..\AvalonStudio.Repository\AvalonStudio.Repository.csproj" />
   </ItemGroup>
 </Project>

--- a/AvalonStudio/AvalonStudio.Debugging.GDB.JLink/AvalonStudio.Debugging.GDB.JLink.csproj
+++ b/AvalonStudio/AvalonStudio.Debugging.GDB.JLink/AvalonStudio.Debugging.GDB.JLink.csproj
@@ -3,7 +3,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
     <OutputTypeEx>library</OutputTypeEx>
   </PropertyGroup>
   <ItemGroup>

--- a/AvalonStudio/AvalonStudio.Debugging.GDB.JLink/JLinkDebugger.cs
+++ b/AvalonStudio/AvalonStudio.Debugging.GDB.JLink/JLinkDebugger.cs
@@ -5,6 +5,9 @@ using AvalonStudio.Toolchains.GCC;
 using Mono.Debugging.Client;
 using System;
 using System.IO;
+using AvalonStudio.Utils;
+using System.Threading.Tasks;
+using AvalonStudio.Packages;
 
 namespace AvalonStudio.Debugging.GDB.JLink
 {
@@ -72,6 +75,11 @@ namespace AvalonStudio.Debugging.GDB.JLink
         public object GetSettingsControl(IProject project)
         {
             return new JLinkSettingsFormViewModel(project);
+        }
+
+        public async Task InstallAsync(IConsole console)
+        {
+            await PackageManager.EnsurePackage("AvalonStudio.Debuggers.JLink", console);
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Debugging.GDB.JLink/JLinkDebugger.cs
+++ b/AvalonStudio/AvalonStudio.Debugging.GDB.JLink/JLinkDebugger.cs
@@ -23,7 +23,7 @@ namespace AvalonStudio.Debugging.GDB.JLink
                 }
                 else
                 {
-                    return Path.Combine(Platform.ReposDirectory, "AvalonStudio.Debugging.JLink\\").ToPlatformPath();
+                    return Path.Combine(PackageManager.GetPackageDirectory("AvalonStudio.Debuggers.JLink"), "content").ToPlatformPath();
                 }
             }
         }

--- a/AvalonStudio/AvalonStudio.Debugging.GDB.JLink/JLinkGdbSession.cs
+++ b/AvalonStudio/AvalonStudio.Debugging.GDB.JLink/JLinkGdbSession.cs
@@ -1,6 +1,8 @@
 ﻿using AvalonStudio.Extensibility;
+using AvalonStudio.Packages;
 using AvalonStudio.Platforms;
 using AvalonStudio.Projects;
+using AvalonStudio.Repositories;
 using AvalonStudio.Utils;
 using Mono.Debugging.Client;
 using System;
@@ -84,6 +86,8 @@ namespace AvalonStudio.Debugging.GDB.JLink
         {
             var result = true;
             var settings = GetSettings(_project);
+
+            PackageManager.EnsurePackage("AvalonStudio.Debuggers.JLink", new AvalonConsoleNuGetLogger(console)).Wait();
 
             console.Clear();
             console.WriteLine("[JLink] - Starting GDB Server...");

--- a/AvalonStudio/AvalonStudio.Debugging.GDB.JLink/JLinkGdbSession.cs
+++ b/AvalonStudio/AvalonStudio.Debugging.GDB.JLink/JLinkGdbSession.cs
@@ -21,21 +21,6 @@ namespace AvalonStudio.Debugging.GDB.JLink
         private Process jlinkProcess;
         public bool DebugMode { get; set; }
 
-        public static string BaseDirectory
-        {
-            get
-            {
-                if (Platform.OSDescription == "Unix")
-                {
-                    return string.Empty;
-                }
-                else
-                {
-                    return Path.Combine(Platform.ReposDirectory, "AvalonStudio.Debugging.JLink\\").ToPlatformPath();
-                }
-            }
-        }
-
         public static JLinkSettings GetSettings(IProject project)
         {
             JLinkSettings result = null;
@@ -92,11 +77,11 @@ namespace AvalonStudio.Debugging.GDB.JLink
             // TODO allow people to select the device.
             var jlinkStartInfo = new ProcessStartInfo();
             jlinkStartInfo.Arguments = string.Format("-select USB -device {0} -if {1} -speed {2} -noir", settings.TargetDevice, Enum.GetName(typeof(JlinkInterfaceType), settings.Interface), settings.SpeedkHz);
-            jlinkStartInfo.FileName = Path.Combine(BaseDirectory, "JLinkGDBServerCL" + Platform.ExecutableExtension);
+            jlinkStartInfo.FileName = Path.Combine(JLinkDebugger.BaseDirectory, "JLinkGDBServerCL" + Platform.ExecutableExtension);
 
             if (Platform.OSDescription == "Unix")
             {
-                jlinkStartInfo.FileName = Path.Combine(BaseDirectory, "JLinkGDBServer" + Platform.ExecutableExtension);
+                jlinkStartInfo.FileName = Path.Combine(JLinkDebugger.BaseDirectory, "JLinkGDBServer" + Platform.ExecutableExtension);
             }
 
             if (Path.IsPathRooted(jlinkStartInfo.FileName) && !System.IO.File.Exists(jlinkStartInfo.FileName))

--- a/AvalonStudio/AvalonStudio.Debugging.GDB.JLink/JLinkGdbSession.cs
+++ b/AvalonStudio/AvalonStudio.Debugging.GDB.JLink/JLinkGdbSession.cs
@@ -87,8 +87,6 @@ namespace AvalonStudio.Debugging.GDB.JLink
             var result = true;
             var settings = GetSettings(_project);
 
-            PackageManager.EnsurePackage("AvalonStudio.Debuggers.JLink", new AvalonConsoleNuGetLogger(console)).Wait();
-
             console.Clear();
             console.WriteLine("[JLink] - Starting GDB Server...");
             // TODO allow people to select the device.

--- a/AvalonStudio/AvalonStudio.Debugging.GDB.Local/AvalonStudio.Debugging.GDB.Local.csproj
+++ b/AvalonStudio/AvalonStudio.Debugging.GDB.Local/AvalonStudio.Debugging.GDB.Local.csproj
@@ -3,7 +3,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
     <OutputTypeEx>library</OutputTypeEx>
   </PropertyGroup>
   <ItemGroup>

--- a/AvalonStudio/AvalonStudio.Debugging.GDB.Local/LocalGdbDebugger.cs
+++ b/AvalonStudio/AvalonStudio.Debugging.GDB.Local/LocalGdbDebugger.cs
@@ -9,6 +9,8 @@
     using Mono.Debugging.Client;
     using System;
     using System.IO;
+    using AvalonStudio.Utils;
+    using System.Threading.Tasks;
 
     public class LocalGdbDebugger : IDebugger2
     {
@@ -59,6 +61,11 @@
         public object GetSettingsControl(IProject project)
         {
             return null;
+        }
+
+        public Task InstallAsync(IConsole console)
+        {
+            return Task.FromResult(0);
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Debugging.GDB.OpenOCD/AvalonStudio.Debugging.GDB.OpenOCD.csproj
+++ b/AvalonStudio/AvalonStudio.Debugging.GDB.OpenOCD/AvalonStudio.Debugging.GDB.OpenOCD.csproj
@@ -3,7 +3,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
     <OutputTypeEx>library</OutputTypeEx>
   </PropertyGroup>
   <ItemGroup>

--- a/AvalonStudio/AvalonStudio.Debugging.GDB/AvalonStudio.Debugging.GDB.csproj
+++ b/AvalonStudio/AvalonStudio.Debugging.GDB/AvalonStudio.Debugging.GDB.csproj
@@ -7,6 +7,7 @@
     <OutputTypeEx>library</OutputTypeEx>
   </PropertyGroup>
   <ItemGroup>
+    <ProjectReference Include="..\AvalonStudio.Debugging\AvalonStudio.Debugging.csproj" />
     <ProjectReference Include="..\AvalonStudio.Extensibility\AvalonStudio.Extensibility.csproj" />
     <ProjectReference Include="..\AvalonStudio.Toolchains.GCC\AvalonStudio.Toolchains.GCC.csproj" />
   </ItemGroup>

--- a/AvalonStudio/AvalonStudio.Debugging.GDB/AvalonStudio.Debugging.GDB.csproj
+++ b/AvalonStudio/AvalonStudio.Debugging.GDB/AvalonStudio.Debugging.GDB.csproj
@@ -3,7 +3,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
     <OutputTypeEx>library</OutputTypeEx>
   </PropertyGroup>
   <ItemGroup>

--- a/AvalonStudio/AvalonStudio.Debugging/AvalonStudio.Debugging.csproj
+++ b/AvalonStudio/AvalonStudio.Debugging/AvalonStudio.Debugging.csproj
@@ -3,7 +3,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="CallStackView.paml" />

--- a/AvalonStudio/AvalonStudio.Debugging/CallStackView.paml
+++ b/AvalonStudio/AvalonStudio.Debugging/CallStackView.paml
@@ -5,7 +5,7 @@
       <ListBox.DataTemplates>
         <DataTemplate DataType="vm:FrameViewModel">
           <StackPanel Orientation="Horizontal" Gap="5" Background="{Binding Background}">
-            <TextBlock Text="{Binding Function}" Width="250" />
+            <TextBlock Text="{Binding Function}" Width="350" />
             <TextBlock Text="{Binding Line}" />
             <TextBlock Text="{Binding Address}" />
             <TextBlock Text="{Binding File}" />

--- a/AvalonStudio/AvalonStudio.Debugging/CallStackView.paml
+++ b/AvalonStudio/AvalonStudio.Debugging/CallStackView.paml
@@ -5,7 +5,7 @@
       <ListBox.DataTemplates>
         <DataTemplate DataType="vm:FrameViewModel">
           <StackPanel Orientation="Horizontal" Gap="5" Background="{Binding Background}">
-            <TextBlock Text="{Binding Function}" Width="350" />
+            <TextBlock Text="{Binding Function}" Width="200" />
             <TextBlock Text="{Binding Line}" />
             <TextBlock Text="{Binding Address}" />
             <TextBlock Text="{Binding File}" />

--- a/AvalonStudio/AvalonStudio.Debugging/CallStackViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/CallStackViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Threading;
 using AvalonStudio.Extensibility;
 using AvalonStudio.Extensibility.Plugin;
 using AvalonStudio.MVVM;
+using AvalonStudio.Platforms;
 using AvalonStudio.Shell;
 using ReactiveUI;
 using System.Collections.ObjectModel;
@@ -38,8 +39,13 @@ namespace AvalonStudio.Debugging
                     var shell = IoC.Get<IShell>();
 
                     _debugManager.SelectedFrame = selectedFrame.Model;
+                    
+                    var file = shell?.CurrentSolution?.FindFile(selectedFrame.Model.SourceLocation.FileName.NormalizePath());
 
-                    shell?.OpenDocument(shell?.CurrentSolution?.FindFile(selectedFrame.Model.SourceLocation.FileName), selectedFrame.Line, -1, -1, true, true);
+                    if (file != null)
+                    {
+                        shell?.OpenDocument(file, selectedFrame.Line, -1, -1, false, true);
+                    }
                 }
 
                 this.RaisePropertyChanged(nameof(SelectedFrame));

--- a/AvalonStudio/AvalonStudio.Debugging/CallStackViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/CallStackViewModel.cs
@@ -76,7 +76,7 @@ namespace AvalonStudio.Debugging
         {
             Frames.Clear();
 
-            for(int i = 0; i < e.Backtrace.FrameCount; i++)
+            for (int i = 0; i < e.Backtrace.FrameCount; i++)
             {
                 var frame = e.Backtrace.GetFrame(i);
 
@@ -87,6 +87,6 @@ namespace AvalonStudio.Debugging
         public void Clear()
         {
             Frames.Clear();
-        }       
+        }
     }
 }

--- a/AvalonStudio/AvalonStudio.Debugging/DebugManager2.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/DebugManager2.cs
@@ -134,9 +134,7 @@
         }
 
         private void OnEndSession()
-        {
-            _session.Exit();
-
+        {            
             Dispatcher.UIThread.InvokeAsync(() =>
             {
                 DebugSessionEnded?.Invoke(this, new EventArgs());
@@ -146,14 +144,15 @@
 
             if (_session != null)
             {
+                _session.Exit();
                 _session.TargetStopped -= _session_TargetStopped;
                 _session.TargetHitBreakpoint -= _session_TargetStopped;
                 _session.TargetExited -= _session_TargetExited;
                 _session.TargetStarted -= _session_TargetStarted;
+                _session.Dispose();
+                _session = null;
             }
-
-            _session?.Dispose();
-            _session = null;
+            
             _lastDocument?.ClearDebugHighlight();
             _lastDocument = null;
 

--- a/AvalonStudio/AvalonStudio.Debugging/DebugManager2.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/DebugManager2.cs
@@ -244,7 +244,7 @@
 
                 if (sourceLocation.FileName != null)
                 {
-                    var normalizedPath = sourceLocation.FileName.Replace("\\\\", "\\").NormalizePath();
+                    var normalizedPath = sourceLocation.FileName.NormalizePath();
 
                     ISourceFile file = null;
 

--- a/AvalonStudio/AvalonStudio.Debugging/DebugManager2.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/DebugManager2.cs
@@ -115,9 +115,12 @@
         {
             _session.Exit();
 
-            DebugSessionEnded?.Invoke(this, new EventArgs());
+            Dispatcher.UIThread.InvokeAsync(() =>
+            {
+                DebugSessionEnded?.Invoke(this, new EventArgs());
 
-            _shell.CurrentPerspective = Perspective.Editor;
+                _shell.CurrentPerspective = Perspective.Editor;
+            });
 
             if (_session != null)
             {

--- a/AvalonStudio/AvalonStudio.Debugging/DebugManager2.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/DebugManager2.cs
@@ -195,6 +195,8 @@
                 return;
             }
 
+            await project.Debugger2.InstallAsync(IoC.Get<IConsole>());
+
             _session = project.Debugger2.CreateSession(project);
 
             _session.Breakpoints = Breakpoints;

--- a/AvalonStudio/AvalonStudio.Debugging/DebugManager2.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/DebugManager2.cs
@@ -247,7 +247,10 @@
                     }
                 }
 
-                TargetStopped?.Invoke(this, e);
+                Dispatcher.UIThread.InvokeAsync(() =>
+                {
+                    TargetStopped?.Invoke(this, e);
+                });
             }
         }
 

--- a/AvalonStudio/AvalonStudio.Debugging/FrameViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/FrameViewModel.cs
@@ -1,47 +1,35 @@
 using AvalonStudio.MVVM;
+using Mono.Debugging.Client;
+using System.IO;
 
 namespace AvalonStudio.Debugging
 {
-    public class FrameViewModel : ViewModel
+    public class FrameViewModel : ViewModel<StackFrame>
     {
         private readonly IDebugManager2 _debugManager;
 
-        public FrameViewModel(IDebugManager2 debugManager)
+        public FrameViewModel(IDebugManager2 debugManager, StackFrame frame) : base(frame)
         {
             _debugManager = debugManager;
         }
 
-        public string Function
-        {
-            get { return "Fn()"; }
-        }
+        public string Function => Path.GetFileName(Model.FullModuleName) + "!" + Model.FullStackframeText;
 
         public string Address
         {
-            get { return string.Format("0x{0:X}", 0); }
+            get { return string.Format("0x{0:X}", Model.Address); }
         }
 
         public int Line
         {
-            get { return 1; }
+            get { return Model.SourceLocation.Line; }
         }
 
         public string File
         {
             get
             {
-                /*if (Model.FullFileName != null)
-				{
-					var filePath = Path.GetDirectoryName(Model.FullFileName);
-
-					var file = Path.GetFileName(Model.FullFileName);
-
-					var relativePath = filePath.MakeRelativePath(_debugManager.Project.CurrentDirectory);
-
-					return Path.Combine(relativePath, file);
-				}*/
-
-                return string.Empty;
+                return Model.SourceLocation.FileName;
             }
         }
     }

--- a/AvalonStudio/AvalonStudio.Debugging/FrameViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/FrameViewModel.cs
@@ -13,7 +13,20 @@ namespace AvalonStudio.Debugging
             _debugManager = debugManager;
         }
 
-        public string Function => Path.GetFileName(Model.FullModuleName) + "!" + Model.FullStackframeText;
+        public string Function
+        {
+            get
+            {
+                if (!string.IsNullOrEmpty(Model.FullModuleName))
+                {
+                    return Path.GetFileName(Model.FullModuleName) + "!" + Model.FullStackframeText;
+                }
+                else
+                {
+                    return Model.FullStackframeText;
+                }
+            }
+        }
 
         public string Address
         {

--- a/AvalonStudio/AvalonStudio.Debugging/IDebugManager2.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/IDebugManager2.cs
@@ -9,9 +9,11 @@
 
         event EventHandler DebugSessionEnded;
 
+        event EventHandler FrameChanged;
+
         event EventHandler<TargetEventArgs> TargetStopped;
 
-        StackFrame LastStackFrame { get; }
+        StackFrame SelectedFrame { get; set; }
 
         DebuggerSession Session { get; }
 

--- a/AvalonStudio/AvalonStudio.Debugging/LocalsViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/LocalsViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Threading;
 using AvalonStudio.Extensibility;
 using AvalonStudio.Extensibility.Plugin;
 using AvalonStudio.MVVM;
+using Mono.Debugging.Client;
 
 namespace AvalonStudio.Debugging
 {
@@ -25,7 +26,7 @@ namespace AvalonStudio.Debugging
 
             if (DebugManager != null)
             {
-                DebugManager.TargetStopped += _debugManager_TargetStopped;
+                DebugManager.FrameChanged += DebugManager_FrameChanged;
 
                 DebugManager.DebugSessionStarted += (sender, e) => { IsVisible = true; };
 
@@ -37,16 +38,16 @@ namespace AvalonStudio.Debugging
             }
         }
 
-        private void _debugManager_TargetStopped(object sender, Mono.Debugging.Client.TargetEventArgs e)
+        private void Update (StackFrame stackFrame)
         {
-            if (e.IsStopEvent)
-            {
-                var currentFrame = e.Backtrace.GetFrame(0);
+            var locals = stackFrame.GetAllLocals();
 
-                var locals = currentFrame.GetAllLocals();
+            InvalidateObjects(locals);
+        }
 
-                InvalidateObjects(locals);
-            }
+        private void DebugManager_FrameChanged(object sender, System.EventArgs e)
+        {
+            Update(DebugManager.SelectedFrame);
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Debugging/VariableControlView.paml
+++ b/AvalonStudio/AvalonStudio.Debugging/VariableControlView.paml
@@ -15,6 +15,7 @@
             <Grid.ContextMenu>
               <ContextMenu>
                 <MenuItem Header="Delete" Command="{Binding DeleteCommand}"/>
+                <MenuItem Header="Add WatchPoint" Command="{Binding AddWatchPointCommand}" />
                 <MenuItem Header="Display as">
                   <MenuItem Header="Hexadecimal" Command="{Binding DisplayFormatCommand}" CommandParameter="hex" />
                   <MenuItem Header="Decimal" Command="{Binding DisplayFormatCommand}" CommandParameter="dec" />

--- a/AvalonStudio/AvalonStudio.Debugging/WatchListViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/WatchListViewModel.cs
@@ -17,7 +17,6 @@ namespace AvalonStudio.Debugging
 
         private readonly List<ObjectValue> watches;
         private List<string> _expressions;
-        private StackFrame _currentFrame;
 
         private ObservableCollection<ObjectValueViewModel> children;
         public List<ObjectValueViewModel> LastChangedRegisters { get; set; }
@@ -33,11 +32,6 @@ namespace AvalonStudio.Debugging
             _expressions = new List<string>();
 
             Activation(); // for when we create the part outside of composition.
-        }
-
-        public void SetCurrentFrame(StackFrame frame)
-        {
-            _currentFrame = frame;
         }
 
         public ObservableCollection<ObjectValueViewModel> Children
@@ -62,7 +56,7 @@ namespace AvalonStudio.Debugging
 
             if (DebugManager != null)
             {
-                DebugManager.TargetStopped += _debugManager_TargetStopped;
+                DebugManager.FrameChanged += DebugManager_FrameChanged;
                 DebugManager.DebugSessionStarted += (sender, e) => { IsVisible = true; };
 
                 DebugManager.DebugSessionEnded += (sender, e) =>
@@ -73,11 +67,9 @@ namespace AvalonStudio.Debugging
             }
         }
 
-        private void _debugManager_TargetStopped(object sender, TargetEventArgs e)
+        private void DebugManager_FrameChanged(object sender, System.EventArgs e)
         {
-            _currentFrame = e.Backtrace.GetFrame(0);
-
-            var expressions = _currentFrame.GetExpressionValues(_expressions.ToArray(), false);
+            var expressions = DebugManager.SelectedFrame.GetExpressionValues(_expressions.ToArray(), false);
 
             InvalidateObjects(expressions);
         }
@@ -167,7 +159,7 @@ namespace AvalonStudio.Debugging
                 {
                     _expressions.Add(expression);
 
-                    var watch = _currentFrame.GetExpressionValue(expression, false);
+                    var watch = DebugManager.SelectedFrame.GetExpressionValue(expression, false);
 
                     InvalidateObjects(watch);
 

--- a/AvalonStudio/AvalonStudio.Debugging/WatchListViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/WatchListViewModel.cs
@@ -161,15 +161,18 @@ namespace AvalonStudio.Debugging
         {
             bool result = false;
 
-            if (DebugManager.SessionActive && !DebugManager.Session.IsRunning && DebugManager.Session.IsConnected && !_expressions.Contains(expression))
+            if (!string.IsNullOrEmpty(expression))
             {
-                _expressions.Add(expression);
+                if (DebugManager.SessionActive && !DebugManager.Session.IsRunning && DebugManager.Session.IsConnected && !_expressions.Contains(expression))
+                {
+                    _expressions.Add(expression);
 
-                var watch = _currentFrame.GetExpressionValue(expression, false);
+                    var watch = _currentFrame.GetExpressionValue(expression, false);
 
-                InvalidateObjects(watch);
+                    InvalidateObjects(watch);
 
-                return true;
+                    return true;
+                }
             }
 
             return result;

--- a/AvalonStudio/AvalonStudio.Debugging/WatchListViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/WatchListViewModel.cs
@@ -131,18 +131,12 @@ namespace AvalonStudio.Debugging
         {
             var newWatch = new ObjectValueViewModel(this, model);
 
-            Dispatcher.UIThread.InvokeTaskAsync(() =>
-            {
-                Children.Add(newWatch);
-            }).Wait();
+            Children.Add(newWatch);
         }
 
         public void Remove(ObjectValue value)
         {
-            Dispatcher.UIThread.InvokeTaskAsync(() =>
-            {
-                Children.Remove(Children.FirstOrDefault(c => c.Model.Name == value.Name));
-            }).Wait();
+            Children.Remove(Children.FirstOrDefault(c => c.Model.Name == value.Name));
         }
 
         private void ApplyChange(ObjectValue change)
@@ -158,10 +152,7 @@ namespace AvalonStudio.Debugging
 
         public virtual void Clear()
         {
-            Dispatcher.UIThread.InvokeAsync(() =>
-            {
-                Children.Clear();
-            });
+            Children.Clear();
 
             watches.Clear();
         }
@@ -176,7 +167,7 @@ namespace AvalonStudio.Debugging
 
                 var watch = _currentFrame.GetExpressionValue(expression, false);
 
-                Task.Run(() => { InvalidateObjects(watch); });
+                InvalidateObjects(watch);
 
                 return true;
             }

--- a/AvalonStudio/AvalonStudio.Debugging/WatchPoint.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/WatchPoint.cs
@@ -1,0 +1,71 @@
+﻿namespace AvalonStudio.Debugging
+{
+    using Mono.Debugging.Client;
+    using System.Xml;
+
+    public class WatchPoint : BreakEvent
+    {
+        public WatchPoint(string expression)
+        {
+            TriggerOnWrite = true;
+            Expression = expression;
+        }
+
+        protected WatchPoint(XmlElement elem, string baseDir) : base(elem, baseDir)
+        {
+            string s = elem.GetAttribute("expression");
+
+            if (!string.IsNullOrEmpty(s))
+            {
+                Expression = s;
+            }
+
+            s = elem.GetAttribute("read");
+
+            bool read = false;
+
+            if (string.IsNullOrEmpty(s) || !bool.TryParse(s, out read))
+            {
+                TriggerOnRead = false;
+            }
+            else
+            {
+                TriggerOnRead = read;
+            }
+
+            s = elem.GetAttribute("write");
+
+            bool write = false;
+
+            if (string.IsNullOrEmpty(s) || !bool.TryParse(s, out write))
+            {
+                TriggerOnWrite = true;
+            }
+            else
+            {
+                TriggerOnWrite = write;
+            }
+        }
+
+        public override XmlElement ToXml(XmlDocument doc, string baseDir)
+        {
+            XmlElement elem = base.ToXml(doc, baseDir);
+
+            if (!string.IsNullOrEmpty(Expression))
+            {
+                elem.SetAttribute("expression", Expression);
+            }
+
+            elem.SetAttribute("read", TriggerOnRead.ToString());
+            elem.SetAttribute("write", TriggerOnWrite.ToString());
+
+            return elem;
+        }
+
+        public string Expression { get; set; }
+
+        public bool TriggerOnRead { get; set; }
+
+        public bool TriggerOnWrite { get; set; }
+    }
+}

--- a/AvalonStudio/AvalonStudio.Debugging/WatchViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/WatchViewModel.cs
@@ -29,6 +29,11 @@ namespace AvalonStudio.Debugging
         public ObjectValueViewModel(WatchListViewModel watchList, ObjectValue model)
             : base(model)
         {
+            if(model == null)
+            {
+                throw new ArgumentNullException(nameof(model));
+            }
+
             this.watchList = watchList;
 
             model.ValueChanged += (sender, e) =>

--- a/AvalonStudio/AvalonStudio.Debugging/WatchViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/WatchViewModel.cs
@@ -51,6 +51,12 @@ namespace AvalonStudio.Debugging
 
             DeleteCommand.Subscribe(_ => { IoC.Get<IWatchList>().Remove(Model); });
 
+            AddWatchPointCommand = ReactiveCommand.Create();
+            AddWatchPointCommand.Subscribe(o =>
+            {
+                IoC.Get<IDebugManager2>().Breakpoints.Add(new WatchPoint(Model.Name));
+            });
+
             DisplayFormatCommand = ReactiveCommand.Create();
             DisplayFormatCommand.Subscribe(s =>
             {
@@ -118,6 +124,8 @@ namespace AvalonStudio.Debugging
         public ReactiveCommand<object> DeleteCommand { get; }
 
         public ReactiveCommand<object> DisplayFormatCommand { get; }
+
+        public ReactiveCommand<object> AddWatchPointCommand { get; }
 
         public string Value
         {

--- a/AvalonStudio/AvalonStudio.Debugging/WatchViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/WatchViewModel.cs
@@ -29,7 +29,7 @@ namespace AvalonStudio.Debugging
         public ObjectValueViewModel(WatchListViewModel watchList, ObjectValue model)
             : base(model)
         {
-            if(model == null)
+            if (model == null)
             {
                 throw new ArgumentNullException(nameof(model));
             }

--- a/AvalonStudio/AvalonStudio.Debugging/WatchViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/WatchViewModel.cs
@@ -88,7 +88,11 @@ namespace AvalonStudio.Debugging
                 else
                 {
                     Children?.Clear();
-                    Children?.Add(DummyChild);
+
+                    if (Model.HasChildren)
+                    {
+                        Children?.Add(DummyChild);
+                    }
                 }
 
                 this.RaiseAndSetIfChanged(ref isExpanded, value);
@@ -180,7 +184,7 @@ namespace AvalonStudio.Debugging
                 }
             }
 
-            if (IsExpanded)
+            if (IsExpanded && Model.HasChildren)
             {
                 if (newValue.Value != null)
                 {
@@ -196,6 +200,10 @@ namespace AvalonStudio.Debugging
                 {
                     Children.Clear();
                 }
+            }
+            else if(IsExpanded && !Model.HasChildren)
+            {
+                IsExpanded = false;
             }
             
             HasChanged = hasChanged;

--- a/AvalonStudio/AvalonStudio.Debugging/WatchViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/WatchViewModel.cs
@@ -123,12 +123,19 @@ namespace AvalonStudio.Debugging
         {
             get
             {
-                if (Model.IsEvaluating)
+                if (Model != null)
                 {
-                    return "Evaluating...";
-                }
+                    if (Model.IsEvaluating)
+                    {
+                        return "Evaluating...";
+                    }
 
-                return Model?.Value;
+                    return Model.Value;
+                }
+                else
+                {
+                    return null;
+                }
             }
         }
 
@@ -209,11 +216,13 @@ namespace AvalonStudio.Debugging
             {
                 if (newValue.Value != null)
                 {
+                    var newChildren = newValue.GetAllChildren();
+                    
                     for (int i = 0; i < Children.Count; i++)
                     {
                         if (Children[i].Model != null)
                         {
-                            Children[i].ApplyChange(newValue.GetChild(Children[i].Model.Name));
+                            Children[i].ApplyChange(newChildren[i]);
                         }
                     }
                 }

--- a/AvalonStudio/AvalonStudio.Debugging/WatchViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/WatchViewModel.cs
@@ -31,6 +31,11 @@ namespace AvalonStudio.Debugging
         {
             this.watchList = watchList;
 
+            model.ValueChanged += (sender, e) =>
+            {
+                this.RaisePropertyChanged(nameof(Value));
+            };
+
             DeleteCommand = ReactiveCommand.Create();
 
             if (model.HasChildren)
@@ -111,7 +116,15 @@ namespace AvalonStudio.Debugging
 
         public string Value
         {
-            get { return Model?.Value; }
+            get
+            {
+                if (Model.IsEvaluating)
+                {
+                    return "Evaluating...";
+                }
+
+                return Model?.Value;
+            }
         }
 
         public IBrush Background
@@ -170,17 +183,20 @@ namespace AvalonStudio.Debugging
             bool hasChanged = Model.Value != newValue?.Value;
             bool didHaveChildren = Model.HasChildren;
 
-            Model = newValue;
-
-            if (Model != null)
+            if ((object)Model != (object)newValue)
             {
-                if (Model.HasChildren && !didHaveChildren)
+                Model = newValue;
+
+                if (Model != null)
                 {
-                    hasChanged = true;
+                    if (Model.HasChildren && !didHaveChildren)
+                    {
+                        hasChanged = true;
 
-                    Children = new ObservableCollection<ObjectValueViewModel>();
+                        Children = new ObservableCollection<ObjectValueViewModel>();
 
-                    Children.Add(DummyChild);
+                        Children.Add(DummyChild);
+                    }
                 }
             }
 
@@ -201,11 +217,11 @@ namespace AvalonStudio.Debugging
                     Children.Clear();
                 }
             }
-            else if(IsExpanded && !Model.HasChildren)
+            else if (IsExpanded && !Model.HasChildren)
             {
                 IsExpanded = false;
             }
-            
+
             HasChanged = hasChanged;
 
             if (hasChanged)

--- a/AvalonStudio/AvalonStudio.Debugging/WatchViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Debugging/WatchViewModel.cs
@@ -197,16 +197,13 @@ namespace AvalonStudio.Debugging
                     Children.Clear();
                 }
             }
+            
+            HasChanged = hasChanged;
 
-            Dispatcher.UIThread.InvokeTaskAsync(() =>
-                {
-                    HasChanged = hasChanged;
-
-                    if (hasChanged)
-                    {
-                        Invalidate();
-                    }
-                }).Wait();
+            if (hasChanged)
+            {
+                Invalidate();
+            }
 
             return result;
         }

--- a/AvalonStudio/AvalonStudio.Extensibility.Tests/AvalonStudio.Extensibility.Tests.csproj
+++ b/AvalonStudio/AvalonStudio.Extensibility.Tests/AvalonStudio.Extensibility.Tests.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/AvalonStudio/AvalonStudio.Extensibility/AvalonStudio.Extensibility.csproj
+++ b/AvalonStudio/AvalonStudio.Extensibility/AvalonStudio.Extensibility.csproj
@@ -3,7 +3,7 @@
     <OutputType>library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.resx" />

--- a/AvalonStudio/AvalonStudio.Extensibility/Debugging/IDebugger.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Debugging/IDebugger.cs
@@ -13,7 +13,7 @@ namespace AvalonStudio.Debugging
         Natural
     }
 
-    public interface IDebugger2 : IExtension
+    public interface IDebugger2 : IExtension, IInstallable
     {
         DebuggerSession CreateSession(IProject project);
 

--- a/AvalonStudio/AvalonStudio.Extensibility/Platform/Platform.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Platform/Platform.cs
@@ -74,6 +74,50 @@ namespace AvalonStudio.Platforms
         internal const string LIBC = "libc";
         private const string LIB = "MonoPosixHelper";
 
+        public static string AvalonRID
+        {
+            get
+            {
+                string result = "UnknownRid";
+
+                switch (Platform.PlatformIdentifier)
+                {
+                    case PlatformID.Win32NT:
+                        result = "win-";
+                        break;
+
+                    case PlatformID.MacOSX:
+                        result = "osx-";
+                        break;
+
+                    case PlatformID.Unix:
+                        result = "ubuntu-";
+                        break;
+                }
+
+                switch (Platform.OSArchitecture)
+                {
+                    case Architecture.X64:
+                        result += "x64";
+                        break;
+
+                    case Architecture.X86:
+                        result += "x86";
+                        break;
+
+                    case Architecture.Arm:
+                        result += "ARM";
+                        break;
+
+                    case Architecture.Arm64:
+                        result += "ARM64";
+                        break;
+                }
+
+                return result;
+            }
+        }
+
         private const string UserDataDir = ".as";
 
         public static string ExecutionPath => Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);

--- a/AvalonStudio/AvalonStudio.Extensibility/Platform/Platform.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Platform/Platform.cs
@@ -441,7 +441,7 @@ namespace AvalonStudio.Platforms
 
         public static string NormalizePath(this string path)
         {
-            string result = path.ToPlatformPath();
+            string result = path.Replace("\\\\", "\\").ToPlatformPath();
 
             if (!string.IsNullOrEmpty(result))
             {

--- a/AvalonStudio/AvalonStudio.Extensibility/Platform/Platform.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Platform/Platform.cs
@@ -441,7 +441,7 @@ namespace AvalonStudio.Platforms
 
         public static string NormalizePath(this string path)
         {
-            string result = path.Replace("\\\\", "\\").ToPlatformPath();
+            string result = path?.Replace("\\\\", "\\").ToPlatformPath();
 
             if (!string.IsNullOrEmpty(result))
             {

--- a/AvalonStudio/AvalonStudio.Extensibility/Plugin/IPlugin.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Plugin/IPlugin.cs
@@ -1,4 +1,6 @@
+using AvalonStudio.Utils;
 using System;
+using System.Threading.Tasks;
 
 namespace AvalonStudio.Extensibility.Plugin
 {
@@ -8,6 +10,11 @@ namespace AvalonStudio.Extensibility.Plugin
         void BeforeActivation();
 
         void Activation();
+    }
+
+    public interface IInstallable
+    {
+        Task InstallAsync(IConsole console);
     }
 
     //[InheritedExport(typeof (IPlugin))]

--- a/AvalonStudio/AvalonStudio.Extensibility/Projects/ISolution.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Projects/ISolution.cs
@@ -6,6 +6,8 @@ namespace AvalonStudio.Projects
     {
         string Name { get; }
 
+        string Location { get; }
+
         IProject StartupProject { get; set; }
 
         ObservableCollection<IProject> Projects { get; }

--- a/AvalonStudio/AvalonStudio.Extensibility/Projects/Solution.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Projects/Solution.cs
@@ -84,6 +84,8 @@ namespace AvalonStudio.Projects
 
         public string Name { get; set; }
 
+        public string Location { get; private set; }
+
         public static IProject LoadProjectFile(ISolution solution, string fileName)
         {
             var shell = IoC.Get<IShell>();
@@ -130,6 +132,7 @@ namespace AvalonStudio.Projects
         {
             var solution = SerializedObject.Deserialize<Solution>(fileName);
 
+            solution.Location = fileName.Normalize().ToPlatformPath();
             solution.CurrentDirectory = (Path.GetDirectoryName(fileName) + Platform.DirectorySeperator).ToPlatformPath();
 
             Console.WriteLine("Solution directory is " + solution.CurrentDirectory);

--- a/AvalonStudio/AvalonStudio.Extensibility/Toolchains/IToolchain.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Toolchains/IToolchain.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace AvalonStudio.Toolchains
 {
-    public interface IToolChain : IPlugin
+    public interface IToolChain : IPlugin, IInstallable
     {
         IEnumerable<string> GetToolchainIncludes(ISourceFile file);
 

--- a/AvalonStudio/AvalonStudio.Extensibility/Utils/GeneralExtensions.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Utils/GeneralExtensions.cs
@@ -2,11 +2,19 @@ using Avalonia;
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Threading.Tasks;
 
 namespace AvalonStudio.Utils
 {
     public static class GeneralExtensions
     {
+        public static void Forget(this Task task)
+        {
+            task.ContinueWith(
+                t => { Console.WriteLine(t.Exception); },
+                TaskContinuationOptions.OnlyOnFaulted);
+        }
+
         public static bool IsFileLocked(this FileInfo file)
         {
             try

--- a/AvalonStudio/AvalonStudio.LanguageSupport.TypeScript/AvalonStudio.LanguageSupport.TypeScript.csproj
+++ b/AvalonStudio/AvalonStudio.LanguageSupport.TypeScript/AvalonStudio.LanguageSupport.TypeScript.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
     <Description />
   </PropertyGroup>
 

--- a/AvalonStudio/AvalonStudio.LanguageSupport.TypeScript/Toolchain/TypeScriptToolchain.cs
+++ b/AvalonStudio/AvalonStudio.LanguageSupport.TypeScript/Toolchain/TypeScriptToolchain.cs
@@ -95,5 +95,10 @@ namespace AvalonStudio.LanguageSupport.TypeScript.Toolchain
             //Irrelevant
             return new string[0];
         }
+
+        public Task InstallAsync(IConsole console)
+        {
+            return Task.FromResult(0);
+        }
     }
 }

--- a/AvalonStudio/AvalonStudio.Languages.CPlusPlus/AvalonStudio.Languages.CPlusPlus.csproj
+++ b/AvalonStudio/AvalonStudio.Languages.CPlusPlus/AvalonStudio.Languages.CPlusPlus.csproj
@@ -3,7 +3,7 @@
     <OutputType>library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
   </PropertyGroup>  
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="0.4.1-build2959-alpha" />

--- a/AvalonStudio/AvalonStudio.Languages.CPlusPlus/CPlusPlusLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.CPlusPlus/CPlusPlusLanguageService.cs
@@ -490,7 +490,7 @@ namespace AvalonStudio.Languages.CPlusPlus
 
                     GenerateDiagnostics(translationUnit.DiagnosticSet.Items, translationUnit, file.Project, result.Diagnostics, dataAssociation.TextMarkerService);
                 }
-                catch (Exception)
+                catch (AccessViolationException e)
                 {
                 }
             });

--- a/AvalonStudio/AvalonStudio.Languages.CSharp/AvalonStudio.Languages.CSharp.csproj
+++ b/AvalonStudio/AvalonStudio.Languages.CSharp/AvalonStudio.Languages.CSharp.csproj
@@ -3,7 +3,7 @@
     <OutputType>library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AvalonStudio/AvalonStudio.MiniShell/AvalonStudio.MiniShell.csproj
+++ b/AvalonStudio/AvalonStudio.MiniShell/AvalonStudio.MiniShell.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/AvalonStudio/AvalonStudio.Projects.CPlusPlus/AvalonStudio.Projects.CPlusPlus.csproj
+++ b/AvalonStudio/AvalonStudio.Projects.CPlusPlus/AvalonStudio.Projects.CPlusPlus.csproj
@@ -3,7 +3,7 @@
     <OutputType>library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.resx" />

--- a/AvalonStudio/AvalonStudio.Projects.OmniSharp/AvalonStudio.Projects.OmniSharp.csproj
+++ b/AvalonStudio/AvalonStudio.Projects.OmniSharp/AvalonStudio.Projects.OmniSharp.csproj
@@ -3,7 +3,7 @@
     <OutputType>library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="ToolchainSettingsFormView.xaml" />

--- a/AvalonStudio/AvalonStudio.Projects.OmniSharp/AvalonStudio.Projects.OmniSharp.csproj
+++ b/AvalonStudio/AvalonStudio.Projects.OmniSharp/AvalonStudio.Projects.OmniSharp.csproj
@@ -15,6 +15,7 @@
   <ItemGroup>
     <ProjectReference Include="..\..\debugger-libs\Mono.Debugging.Win32\Mono.Debugging.Win32.NetCore2.csproj" />
     <ProjectReference Include="..\AvalonStudio.Extensibility\AvalonStudio.Extensibility.csproj" />
+    <ProjectReference Include="..\AvalonStudio.Repository\AvalonStudio.Repository.csproj" />
   </ItemGroup>
 
 </Project>

--- a/AvalonStudio/AvalonStudio.Projects.OmniSharp/Debugger/DotNetCoreDebugSessionProvider.cs
+++ b/AvalonStudio/AvalonStudio.Projects.OmniSharp/Debugger/DotNetCoreDebugSessionProvider.cs
@@ -24,6 +24,7 @@
         {
             var settings = SettingsBase.GetSettings<DotNetToolchainSettings>();
 
+            // TODO resolve correct paths.
             var dbgShimPath = Path.Combine(Path.GetDirectoryName(settings.DotNetPath), "shared", "Microsoft.NETCore.App", "2.0.0-preview1-002021-00", "dbgshim" + Platform.DLLExtension);
 
             var result = new CoreClrDebuggerSession(System.IO.Path.GetInvalidPathChars(), dbgShimPath);

--- a/AvalonStudio/AvalonStudio.Projects.OmniSharp/Debugger/DotNetCoreDebugSessionProvider.cs
+++ b/AvalonStudio/AvalonStudio.Projects.OmniSharp/Debugger/DotNetCoreDebugSessionProvider.cs
@@ -9,6 +9,9 @@
     using Mono.Debugging.Client;
     using Mono.Debugging.Win32;
     using System.IO;
+    using AvalonStudio.Utils;
+    using System;
+    using System.Threading.Tasks;
 
     public class DotNetCoreDebugger : IDebugger2
     {
@@ -101,6 +104,11 @@
         public object GetSettingsControl(IProject project)
         {
             return null;
+        }
+
+        public Task InstallAsync(IConsole console)
+        {
+            return Task.FromResult(0);
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Projects.OmniSharp/OmniSharp/OmniSharpServer.cs
+++ b/AvalonStudio/AvalonStudio.Projects.OmniSharp/OmniSharp/OmniSharpServer.cs
@@ -62,14 +62,14 @@
             return responseReceived.Task;
         }
 
-        public Task<Process> StartAsync(string projectDir)
+        public async Task<Process> StartAsync(string projectDir)
         {
             var startInfo = new ProcessStartInfo();            
 
             startInfo.FileName = Binary;
             startInfo.Arguments = $"-p {port} -s {projectDir}";
 
-            PackageManager.EnsurePackage("AvalonStudio.Languages.CSharp", new AvalonConsoleNuGetLogger(IoC.Get<IConsole>())).Wait();
+            await PackageManager.EnsurePackage("AvalonStudio.Languages.CSharp", IoC.Get<IConsole>());
 
             //// Hide console window
             //startInfo.UseShellExecute = false;
@@ -79,7 +79,7 @@
             //startInfo.CreateNoWindow = true;
             TaskCompletionSource<Process> processStartedCompletionSource = new TaskCompletionSource<Process>();
 
-            Task.Factory.StartNew(async () =>
+            Task.Run(async () =>
             {
                 process = Process.Start(startInfo);
 
@@ -98,9 +98,9 @@
                 processStartedCompletionSource.SetResult(process);
 
                 process.WaitForExit();
-            });
+            }).Forget();
 
-            return processStartedCompletionSource.Task;
+            return await processStartedCompletionSource.Task;
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Projects.OmniSharp/OmniSharp/OmniSharpServer.cs
+++ b/AvalonStudio/AvalonStudio.Projects.OmniSharp/OmniSharp/OmniSharpServer.cs
@@ -1,17 +1,23 @@
 ﻿namespace AvalonStudio.Languages.CSharp.OmniSharp
 {
+    using AvalonStudio.Extensibility;
+    using AvalonStudio.Packages;
     using AvalonStudio.Platforms;
+    using AvalonStudio.Repositories;
+    using AvalonStudio.Utils;
     using Extensibility.Languages.CompletionAssistance;
     using RestSharp;
+    using System;
     using System.Collections.Generic;
     using System.Diagnostics;
     using System.IO;
+    using System.Linq;
     using System.Threading;
     using System.Threading.Tasks;
 
     public class OmniSharpServer
     {
-        private static readonly string BaseDir = Path.Combine(Platform.ReposDirectory, "AvalonStudio.Languages.CSharp", "OmniSharp");
+        private static readonly string BaseDir = PackageManager.GetPackageDirectory("AvalonStudio.Languages.CSharp");
         private static readonly string Binary = Path.Combine(BaseDir, $"OmniSharp{Platform.ExecutableExtension}");
         private Process process;
         private RestClient client;
@@ -58,9 +64,12 @@
 
         public Task<Process> StartAsync(string projectDir)
         {
-            var startInfo = new ProcessStartInfo();
+            var startInfo = new ProcessStartInfo();            
+
             startInfo.FileName = Binary;
             startInfo.Arguments = $"-p {port} -s {projectDir}";
+
+            PackageManager.EnsurePackage("AvalonStudio.Languages.CSharp", new AvalonConsoleNuGetLogger(IoC.Get<IConsole>())).Wait();
 
             //// Hide console window
             //startInfo.UseShellExecute = false;

--- a/AvalonStudio/AvalonStudio.Projects.OmniSharp/OmniSharpSolution.cs
+++ b/AvalonStudio/AvalonStudio.Projects.OmniSharp/OmniSharpSolution.cs
@@ -30,6 +30,8 @@ namespace AvalonStudio.Projects.OmniSharp
 
         private async Task LoadSolution(string path)
         {
+            Name = Path.GetFileNameWithoutExtension(path);
+
             await server.StartAsync(Path.GetDirectoryName(path));
 
             var workspace = await server.SendRequest(new WorkspaceInformationRequest() { ExcludeSourceFiles = false });

--- a/AvalonStudio/AvalonStudio.Projects.OmniSharp/OmniSharpSolution.cs
+++ b/AvalonStudio/AvalonStudio.Projects.OmniSharp/OmniSharpSolution.cs
@@ -30,6 +30,8 @@ namespace AvalonStudio.Projects.OmniSharp
 
         private async Task LoadSolution(string path)
         {
+            Location = path;
+
             Name = Path.GetFileNameWithoutExtension(path);
 
             await server.StartAsync(Path.GetDirectoryName(path));
@@ -66,6 +68,8 @@ namespace AvalonStudio.Projects.OmniSharp
         public ObservableCollection<IProject> Projects { get; set; }
 
         public IProject StartupProject { get; set; }
+
+        public string Location { get; private set; }
 
         public ISourceFile FindFile(string file)
         {

--- a/AvalonStudio/AvalonStudio.Projects.OmniSharp/Toolchain/MSBuildToolchain.cs
+++ b/AvalonStudio/AvalonStudio.Projects.OmniSharp/Toolchain/MSBuildToolchain.cs
@@ -99,6 +99,11 @@
             return new List<string>();
         }
 
+        public Task InstallAsync(IConsole console)
+        {
+            return Task.FromResult(0);
+        }
+
         public void ProvisionSettings(IProject project)
         {
         }

--- a/AvalonStudio/AvalonStudio.Projects.Standard/AvalonStudio.Projects.Standard.csproj
+++ b/AvalonStudio/AvalonStudio.Projects.Standard/AvalonStudio.Projects.Standard.csproj
@@ -3,7 +3,7 @@
     <OutputType>library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.resx" />

--- a/AvalonStudio/AvalonStudio.Repository/AvalonConsoleNuGetLogger.cs
+++ b/AvalonStudio/AvalonStudio.Repository/AvalonConsoleNuGetLogger.cs
@@ -1,0 +1,33 @@
+﻿using AvalonStudio.Utils;
+using NuGet.Common;
+
+namespace AvalonStudio.Repositories
+{
+    public class AvalonConsoleNuGetLogger : ILogger
+    {
+        private IConsole _console;
+
+        public AvalonConsoleNuGetLogger(IConsole console)
+        {
+            _console = console;
+        }
+
+        public void LogDebug(string data) => _console.WriteLine(data);
+
+        public void LogVerbose(string data) => _console.WriteLine(data);
+
+        public void LogInformation(string data) => _console.WriteLine(data);
+
+        public void LogMinimal(string data) => _console.WriteLine(data);
+
+        public void LogWarning(string data) => _console.WriteLine(data);
+
+        public void LogError(string data) => _console.WriteLine(data);
+
+        public void LogSummary(string data) => _console.WriteLine(data);
+
+        public void LogInformationSummary(string data) => _console.WriteLine(data);
+
+        public void LogErrorSummary(string data) => _console.WriteLine(data);
+    }
+}

--- a/AvalonStudio/AvalonStudio.Repository/Logger.cs
+++ b/AvalonStudio/AvalonStudio.Repository/Logger.cs
@@ -1,4 +1,5 @@
-﻿using NuGet.Common;
+﻿using AvalonStudio.Utils;
+using NuGet.Common;
 
 namespace AvalonStudio.Repositories
 {
@@ -21,5 +22,33 @@ namespace AvalonStudio.Repositories
         public void LogInformationSummary(string data) => $"Infosummary: {data}".Dump();
 
         public void LogErrorSummary(string data) => $"LogErrorSummary: {data }".Dump();
+    }
+
+    public class AvalonConsoleNuGetLogger : ILogger
+    {
+        private IConsole _console;
+
+        public AvalonConsoleNuGetLogger(IConsole console)
+        {
+            _console = console;
+        }
+
+        public void LogDebug(string data) => _console.Write(data);
+
+        public void LogVerbose(string data) => _console.Write(data);
+
+        public void LogInformation(string data) => _console.Write(data);
+
+        public void LogMinimal(string data) => _console.Write(data);
+
+        public void LogWarning(string data) => _console.Write(data);
+
+        public void LogError(string data) => _console.Write(data);
+
+        public void LogSummary(string data) => _console.Write(data);
+
+        public void LogInformationSummary(string data) => _console.Write(data);
+
+        public void LogErrorSummary(string data) => _console.Write(data);
     }
 }

--- a/AvalonStudio/AvalonStudio.Repository/Logger.cs
+++ b/AvalonStudio/AvalonStudio.Repository/Logger.cs
@@ -33,22 +33,22 @@ namespace AvalonStudio.Repositories
             _console = console;
         }
 
-        public void LogDebug(string data) => _console.Write(data);
+        public void LogDebug(string data) => _console.WriteLine(data);
 
-        public void LogVerbose(string data) => _console.Write(data);
+        public void LogVerbose(string data) => _console.WriteLine(data);
 
-        public void LogInformation(string data) => _console.Write(data);
+        public void LogInformation(string data) => _console.WriteLine(data);
 
-        public void LogMinimal(string data) => _console.Write(data);
+        public void LogMinimal(string data) => _console.WriteLine(data);
 
-        public void LogWarning(string data) => _console.Write(data);
+        public void LogWarning(string data) => _console.WriteLine(data);
 
-        public void LogError(string data) => _console.Write(data);
+        public void LogError(string data) => _console.WriteLine(data);
 
-        public void LogSummary(string data) => _console.Write(data);
+        public void LogSummary(string data) => _console.WriteLine(data);
 
-        public void LogInformationSummary(string data) => _console.Write(data);
+        public void LogInformationSummary(string data) => _console.WriteLine(data);
 
-        public void LogErrorSummary(string data) => _console.Write(data);
+        public void LogErrorSummary(string data) => _console.WriteLine(data);
     }
 }

--- a/AvalonStudio/AvalonStudio.Repository/Logger.cs
+++ b/AvalonStudio/AvalonStudio.Repository/Logger.cs
@@ -1,5 +1,4 @@
-﻿using AvalonStudio.Utils;
-using NuGet.Common;
+﻿using NuGet.Common;
 
 namespace AvalonStudio.Repositories
 {
@@ -22,33 +21,5 @@ namespace AvalonStudio.Repositories
         public void LogInformationSummary(string data) => $"Infosummary: {data}".Dump();
 
         public void LogErrorSummary(string data) => $"LogErrorSummary: {data }".Dump();
-    }
-
-    public class AvalonConsoleNuGetLogger : ILogger
-    {
-        private IConsole _console;
-
-        public AvalonConsoleNuGetLogger(IConsole console)
-        {
-            _console = console;
-        }
-
-        public void LogDebug(string data) => _console.WriteLine(data);
-
-        public void LogVerbose(string data) => _console.WriteLine(data);
-
-        public void LogInformation(string data) => _console.WriteLine(data);
-
-        public void LogMinimal(string data) => _console.WriteLine(data);
-
-        public void LogWarning(string data) => _console.WriteLine(data);
-
-        public void LogError(string data) => _console.WriteLine(data);
-
-        public void LogSummary(string data) => _console.WriteLine(data);
-
-        public void LogInformationSummary(string data) => _console.WriteLine(data);
-
-        public void LogErrorSummary(string data) => _console.WriteLine(data);
     }
 }

--- a/AvalonStudio/AvalonStudio.Repository/PackageManager.cs
+++ b/AvalonStudio/AvalonStudio.Repository/PackageManager.cs
@@ -48,22 +48,29 @@ namespace AvalonStudio.Packages
             return new InstalledPackagesCache(Path.Combine(Platform.ReposDirectory, "cachedPackages.xml"), Path.Combine(Platform.ReposDirectory, "installedPackages.xml"), false);
         }
 
-        public static async Task EnsurePackage(string packageId, ILogger console)
+        public static async Task EnsurePackage(string packageId, IConsole console)
+        {
+            await EnsurePackage(packageId, new AvalonConsoleNuGetLogger(console));
+        }
+
+        private static async Task EnsurePackage(string packageId, ILogger console)
         {
             if(GetPackageDirectory(packageId)== string.Empty)
             {
                 console.LogInformation($"Package: {packageId} will be installed.");
 
-                var packages = await FindPackages(packageId + "-" + Platform.AvalonRID);
+                var packages = await FindPackages(packageId + "." + Platform.AvalonRID);
 
                 var package = packages.FirstOrDefault();
 
-                if(package == null)
+                if (package == null)
                 {
                     console.LogInformation($"Unable to find package: {packageId}");
                 }
-
-                await InstallPackage(package.Identity.Id, package.Identity.Version.ToNormalizedString(), console);
+                else
+                {
+                    await InstallPackage(package.Identity.Id, package.Identity.Version.ToNormalizedString(), console);
+                }
             }
         }
 

--- a/AvalonStudio/AvalonStudio.Repository/PackageManager.cs
+++ b/AvalonStudio/AvalonStudio.Repository/PackageManager.cs
@@ -24,7 +24,7 @@ namespace AvalonStudio.Packages
 {
     public class PackageManager
     {
-        private ILogger _logger;        
+        private ILogger _logger;
 
         public PackageManager(ILogger logger = null)
         {
@@ -55,7 +55,7 @@ namespace AvalonStudio.Packages
 
         private static async Task EnsurePackage(string packageId, ILogger console)
         {
-            if(GetPackageDirectory(packageId)== string.Empty)
+            if (GetPackageDirectory(packageId) == string.Empty)
             {
                 console.LogInformation($"Package: {packageId} will be installed.");
 
@@ -112,7 +112,7 @@ namespace AvalonStudio.Packages
                     INuGetProjectContext projectContext = new ProjectContext(logger);
                     var sourceRepositories = new List<SourceRepository>();
                     sourceRepositories.Add(new SourceRepository(new NuGet.Configuration.PackageSource(DefaultPackageSource), providers));
-                    
+
                     await packageManager.InstallPackageAsync(packageManager.PackagesFolderNuGetProject,
                         identity, resolutionContext, projectContext, sourceRepositories,
                         Array.Empty<SourceRepository>(),  // This is a list of secondary source respositories, probably empty
@@ -127,7 +127,7 @@ namespace AvalonStudio.Packages
 
         public static async Task UninstallPackage(string packageId, string version, ILogger logger = null)
         {
-            if(logger == null)
+            if (logger == null)
             {
                 logger = new ConsoleNuGetLogger();
             }
@@ -199,7 +199,7 @@ namespace AvalonStudio.Packages
 
         public static async Task<IEnumerable<IPackageSearchMetadata>> FindPackages(string packageName, ILogger logger = null)
         {
-            if(logger == null)
+            if (logger == null)
             {
                 logger = new ConsoleNuGetLogger();
             }
@@ -225,7 +225,7 @@ namespace AvalonStudio.Packages
             }
         }
 
-        public static string GetPackageDirectory (PackageIdentity identity)
+        public static string GetPackageDirectory(PackageIdentity identity)
         {
             string result = string.Empty;
 
@@ -239,7 +239,7 @@ namespace AvalonStudio.Packages
             return result;
         }
 
-        public static string GetPackageDirectory (string genericPackageId)
+        public static string GetPackageDirectory(string genericPackageId)
         {
             var result = string.Empty;
 
@@ -247,7 +247,7 @@ namespace AvalonStudio.Packages
 
             var latest = packageIds.OrderByDescending(id => id.Version).FirstOrDefault();
 
-            if(latest != null)
+            if (latest != null)
             {
                 result = GetPackageDirectory(latest);
             }

--- a/AvalonStudio/AvalonStudio.TestFrameworks.Catch/AvalonStudio.TestFrameworks.Catch.csproj
+++ b/AvalonStudio/AvalonStudio.TestFrameworks.Catch/AvalonStudio.TestFrameworks.Catch.csproj
@@ -4,7 +4,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
     <ApplicationIcon />
     <OutputTypeEx>library</OutputTypeEx>
     <StartupObject />

--- a/AvalonStudio/AvalonStudio.Toolchains.Clang/AvalonStudio.Toolchains.Clang.csproj
+++ b/AvalonStudio/AvalonStudio.Toolchains.Clang/AvalonStudio.Toolchains.Clang.csproj
@@ -12,6 +12,7 @@
     <ProjectReference Include="..\AvalonStudio.Extensibility\AvalonStudio.Extensibility.csproj" />
     <ProjectReference Include="..\AvalonStudio.Projects.CPlusPlus\AvalonStudio.Projects.CPlusPlus.csproj" />
     <ProjectReference Include="..\AvalonStudio.Projects.Standard\AvalonStudio.Projects.Standard.csproj" />
+    <ProjectReference Include="..\AvalonStudio.Repository\AvalonStudio.Repository.csproj" />
     <ProjectReference Include="..\AvalonStudio.Toolchains.GCC\AvalonStudio.Toolchains.GCC.csproj" />
     <ProjectReference Include="..\AvalonStudio.Toolchains.Standard\AvalonStudio.Toolchains.Standard.csproj" />
   </ItemGroup>

--- a/AvalonStudio/AvalonStudio.Toolchains.Clang/AvalonStudio.Toolchains.Clang.csproj
+++ b/AvalonStudio/AvalonStudio.Toolchains.Clang/AvalonStudio.Toolchains.Clang.csproj
@@ -3,7 +3,7 @@
     <OutputType>library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.resx" />

--- a/AvalonStudio/AvalonStudio.Toolchains.Clang/ClangToolchain.cs
+++ b/AvalonStudio/AvalonStudio.Toolchains.Clang/ClangToolchain.cs
@@ -5,7 +5,6 @@ namespace AvalonStudio.Toolchains.Clang
     using AvalonStudio.Platforms;
     using AvalonStudio.Projects;
     using AvalonStudio.Projects.Standard;
-    using AvalonStudio.Repositories;
     using AvalonStudio.Toolchains.GCC;
     using AvalonStudio.Utils;
     using CommandLineTools;
@@ -25,7 +24,8 @@ namespace AvalonStudio.Toolchains.Clang
 
     public class ClangToolchain : GCCToolchain
     {
-        public override string BinDirectory => Path.Combine(PackageManager.GetPackageDirectory("AvalonStudio.Toolchains.Clang"), "content", "bin");
+        public static string ContentDirectory => Path.Combine(PackageManager.GetPackageDirectory("AvalonStudio.Toolchains.Clang"), "content");
+        public override string BinDirectory => Path.Combine(ContentDirectory, "bin");
         public override string Prefix => string.Empty;
         public override string CCName => "clang";
         public override string CCPPName => "clang++";
@@ -65,24 +65,17 @@ namespace AvalonStudio.Toolchains.Clang
             return Path.Combine(project.CurrentDirectory, "link.ld");
         }
 
-        public override CompileResult Compile(IConsole console, IStandardProject superProject, IStandardProject project, ISourceFile file, string outputFile)
-        {
-            PackageManager.EnsurePackage("AvalonStudio.Toolchains.Clang", new AvalonConsoleNuGetLogger(console)).Wait();
-
-            return base.Compile(console, superProject, project, file, outputFile);
-        }
-
         public override IEnumerable<string> GetToolchainIncludes(ISourceFile file)
         {
             return new List<string>
             {
-                Path.Combine(Platform.ReposDirectory, "AvalonStudio.Toolchains.Clang", "arm-none-eabi", "include", "c++", "5.4.1"),
-                Path.Combine(Platform.ReposDirectory, "AvalonStudio.Toolchains.Clang", "arm-none-eabi", "include", "c++", "5.4.1", "arm-none-eabi"),
-                Path.Combine(Platform.ReposDirectory, "AvalonStudio.Toolchains.Clang", "arm-none-eabi", "include", "c++", "5.4.1", "backward"),
-                Path.Combine(Platform.ReposDirectory, "AvalonStudio.Toolchains.Clang", "arm-none-eabi", "include"),
-                Path.Combine(Platform.ReposDirectory, "AvalonStudio.Toolchains.Clang", "lib", "gcc", "arm-none-eabi", "5.4.1", "include"),
-                Path.Combine(Platform.ReposDirectory, "AvalonStudio.Toolchains.Clang", "lib", "gcc", "arm-none-eabi", "5.4.1", "include-fixed"),
-                Path.Combine(Platform.ReposDirectory, "AvalonStudio.Toolchains.Clang", "arm-none-eabi", "include")
+                Path.Combine(ContentDirectory, "arm-none-eabi", "include", "c++", "5.4.1"),
+                Path.Combine(ContentDirectory, "arm-none-eabi", "include", "c++", "5.4.1", "arm-none-eabi"),
+                Path.Combine(ContentDirectory, "arm-none-eabi", "include", "c++", "5.4.1", "backward"),
+                Path.Combine(ContentDirectory, "arm-none-eabi", "include"),
+                Path.Combine(ContentDirectory, "lib", "gcc", "arm-none-eabi", "5.4.1", "include"),
+                Path.Combine(ContentDirectory, "lib", "gcc", "arm-none-eabi", "5.4.1", "include-fixed"),
+                Path.Combine(ContentDirectory, "arm-none-eabi", "include")
             };
         }
 
@@ -497,6 +490,11 @@ namespace AvalonStudio.Toolchains.Clang
             }
 
             return true;
+        }
+
+        public async override Task InstallAsync(IConsole console)
+        {
+            await PackageManager.EnsurePackage("AvalonStudio.Toolchains.Clang", console);
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Toolchains.Clang/ClangToolchain.cs
+++ b/AvalonStudio/AvalonStudio.Toolchains.Clang/ClangToolchain.cs
@@ -1,9 +1,11 @@
 namespace AvalonStudio.Toolchains.Clang
 {
     using AvalonStudio.Extensibility.Templating;
+    using AvalonStudio.Packages;
     using AvalonStudio.Platforms;
     using AvalonStudio.Projects;
     using AvalonStudio.Projects.Standard;
+    using AvalonStudio.Repositories;
     using AvalonStudio.Toolchains.GCC;
     using AvalonStudio.Utils;
     using CommandLineTools;
@@ -23,7 +25,7 @@ namespace AvalonStudio.Toolchains.Clang
 
     public class ClangToolchain : GCCToolchain
     {
-        public override string BinDirectory => Path.Combine(Platform.ReposDirectory, "AvalonStudio.Toolchains.Clang", "bin");
+        public override string BinDirectory => Path.Combine(PackageManager.GetPackageDirectory("AvalonStudio.Toolchains.Clang"), "content", "bin");
         public override string Prefix => string.Empty;
         public override string CCName => "clang";
         public override string CCPPName => "clang++";
@@ -61,6 +63,13 @@ namespace AvalonStudio.Toolchains.Clang
         private string GetLinkerScriptLocation(IStandardProject project)
         {
             return Path.Combine(project.CurrentDirectory, "link.ld");
+        }
+
+        public override CompileResult Compile(IConsole console, IStandardProject superProject, IStandardProject project, ISourceFile file, string outputFile)
+        {
+            PackageManager.EnsurePackage("AvalonStudio.Toolchains.Clang", new AvalonConsoleNuGetLogger(console)).Wait();
+
+            return base.Compile(console, superProject, project, file, outputFile);
         }
 
         public override IEnumerable<string> GetToolchainIncludes(ISourceFile file)

--- a/AvalonStudio/AvalonStudio.Toolchains.GCC/AvalonStudio.Toolchains.GCC.csproj
+++ b/AvalonStudio/AvalonStudio.Toolchains.GCC/AvalonStudio.Toolchains.GCC.csproj
@@ -3,7 +3,7 @@
     <OutputType>library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.resx" />

--- a/AvalonStudio/AvalonStudio.Toolchains.LocalGCC/AvalonStudio.Toolchains.LocalGCC.csproj
+++ b/AvalonStudio/AvalonStudio.Toolchains.LocalGCC/AvalonStudio.Toolchains.LocalGCC.csproj
@@ -20,6 +20,7 @@
     <ProjectReference Include="..\AvalonStudio.Extensibility\AvalonStudio.Extensibility.csproj" />
     <ProjectReference Include="..\AvalonStudio.Languages.CPlusPlus\AvalonStudio.Languages.CPlusPlus.csproj" />
     <ProjectReference Include="..\AvalonStudio.Projects.CPlusPlus\AvalonStudio.Projects.CPlusPlus.csproj" />
+    <ProjectReference Include="..\AvalonStudio.Repository\AvalonStudio.Repository.csproj" />
     <ProjectReference Include="..\AvalonStudio.Toolchains.GCC\AvalonStudio.Toolchains.GCC.csproj" />
   </ItemGroup>
 </Project>

--- a/AvalonStudio/AvalonStudio.Toolchains.LocalGCC/AvalonStudio.Toolchains.LocalGCC.csproj
+++ b/AvalonStudio/AvalonStudio.Toolchains.LocalGCC/AvalonStudio.Toolchains.LocalGCC.csproj
@@ -3,7 +3,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
     <OutputTypeEx>library</OutputTypeEx>
   </PropertyGroup>
   <ItemGroup>

--- a/AvalonStudio/AvalonStudio.Toolchains.LocalGCC/LocalGCCToolchain.cs
+++ b/AvalonStudio/AvalonStudio.Toolchains.LocalGCC/LocalGCCToolchain.cs
@@ -1,3 +1,4 @@
+using AvalonStudio.Packages;
 using AvalonStudio.Platforms;
 using AvalonStudio.Projects;
 using AvalonStudio.Projects.Standard;
@@ -329,6 +330,11 @@ namespace AvalonStudio.Toolchains.LocalGCC
             }
 
             return result;
+        }
+
+        public async override Task InstallAsync(IConsole console)
+        {
+            await PackageManager.EnsurePackage("AvalonStudio.Toolchains.LocalGCC", console);
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Toolchains.STM32/AvalonStudio.Toolchains.STM32.csproj
+++ b/AvalonStudio/AvalonStudio.Toolchains.STM32/AvalonStudio.Toolchains.STM32.csproj
@@ -18,6 +18,7 @@
   <ItemGroup>
     <ProjectReference Include="..\AvalonStudio.Extensibility\AvalonStudio.Extensibility.csproj" />
     <ProjectReference Include="..\AvalonStudio.Languages.CPlusPlus\AvalonStudio.Languages.CPlusPlus.csproj" />
+    <ProjectReference Include="..\AvalonStudio.Repository\AvalonStudio.Repository.csproj" />
     <ProjectReference Include="..\AvalonStudio.Toolchains.GCC\AvalonStudio.Toolchains.GCC.csproj" />
   </ItemGroup>
 </Project>

--- a/AvalonStudio/AvalonStudio.Toolchains.STM32/AvalonStudio.Toolchains.STM32.csproj
+++ b/AvalonStudio/AvalonStudio.Toolchains.STM32/AvalonStudio.Toolchains.STM32.csproj
@@ -3,7 +3,7 @@
     <OutputType>Library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
     <OutputTypeEx>library</OutputTypeEx>
   </PropertyGroup>
   <ItemGroup>

--- a/AvalonStudio/AvalonStudio.Toolchains.STM32/STM32GCCToolchain.cs
+++ b/AvalonStudio/AvalonStudio.Toolchains.STM32/STM32GCCToolchain.cs
@@ -1,5 +1,6 @@
 namespace AvalonStudio.Toolchains.STM32
 {
+    using AvalonStudio.Packages;
     using AvalonStudio.Platforms;
     using AvalonStudio.Projects;
     using AvalonStudio.Projects.Standard;
@@ -491,6 +492,11 @@ namespace AvalonStudio.Toolchains.STM32
             }
 
             return true;
+        }
+
+        public async override Task InstallAsync(IConsole console)
+        {
+            await PackageManager.EnsurePackage("AvalonStudio.Toolchains.STM32", console);
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Toolchains.Standard/AvalonStudio.Toolchains.Standard.csproj
+++ b/AvalonStudio/AvalonStudio.Toolchains.Standard/AvalonStudio.Toolchains.Standard.csproj
@@ -3,7 +3,7 @@
     <OutputType>library</OutputType>
     <TargetFramework>netcoreapp2.0</TargetFramework>
     <RuntimeFrameworkVersion>2.0.0-preview1-001978-00</RuntimeFrameworkVersion>
-    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net40</PackageTargetFallback>
+    <PackageTargetFallback>$(PackageTargetFallback);netstandard1.3;net45</PackageTargetFallback>
   </PropertyGroup>
   <ItemGroup>
     <EmbeddedResource Include="**\*.resx" />

--- a/AvalonStudio/AvalonStudio.Toolchains.Standard/StandardToolChain.cs
+++ b/AvalonStudio/AvalonStudio.Toolchains.Standard/StandardToolChain.cs
@@ -36,6 +36,8 @@ namespace AvalonStudio.Toolchains.Standard
 
         public async Task<bool> Build(IConsole console, IProject project, string label = "", IEnumerable<string> defines = null)
         {
+            await InstallAsync(console);
+
             if (!ValidateToolchainExecutables(console))
             {
                 return false;
@@ -549,5 +551,7 @@ namespace AvalonStudio.Toolchains.Standard
         public abstract Task<bool> PreBuild(IConsole console, IProject project);
 
         public abstract Task<bool> PostBuild(IConsole console, IProject project, LinkResult linkResult);
+
+        public abstract Task InstallAsync(IConsole console);
     }
 }

--- a/AvalonStudio/AvalonStudio/Controls/Editor/EditorViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/Editor/EditorViewModel.cs
@@ -436,7 +436,10 @@ namespace AvalonStudio.Controls
 
         public void GotoPosition(int line, int column)
         {
-            Dispatcher.UIThread.InvokeAsync(() => { CaretIndex = TextDocument.GetOffset(line, column); });
+            if (textDocument != null)
+            {
+                Dispatcher.UIThread.InvokeAsync(() => { CaretIndex = TextDocument.GetOffset(line, column); });
+            }
         }
 
         public void GotoOffset(int offset)

--- a/AvalonStudio/AvalonStudio/Controls/Editor/EditorViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/Editor/EditorViewModel.cs
@@ -170,8 +170,8 @@ namespace AvalonStudio.Controls
 
                 Model.TextDocument = null;
             }));
-            
-            AddWatchCommand = ReactiveCommand.Create(this.WhenAny(x=>x.WordAtCaret, (word) => !string.IsNullOrEmpty(word.Value)));
+
+            AddWatchCommand = ReactiveCommand.Create(this.WhenAny(x => x.WordAtCaret, (word) => !string.IsNullOrEmpty(word.Value)));
             disposables.Add(AddWatchCommand.Subscribe(_ => { IoC.Get<IWatchList>()?.AddWatch(WordAtCaret); }));
 
             tabCharacter = "    ";
@@ -602,16 +602,12 @@ namespace AvalonStudio.Controls
                 {
                     var debugManager = IoC.Get<IDebugManager2>();
 
-                    if (debugManager.LastStackFrame != null)
-                    {
-                        var newToolTip = new DebugHoverProbeViewModel();
-                        newToolTip.SetCurrentFrame(debugManager.LastStackFrame);
+                    var newToolTip = new DebugHoverProbeViewModel();
 
-                        bool result = newToolTip.AddWatch(expression);
+                    bool result = newToolTip.AddWatch(expression);
 
-                        ToolTip = newToolTip;
-                        return result;
-                    }
+                    ToolTip = newToolTip;
+                    return result;
                 }
             }
 

--- a/AvalonStudio/AvalonStudio/Controls/Editor/EditorViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/Editor/EditorViewModel.cs
@@ -170,8 +170,8 @@ namespace AvalonStudio.Controls
 
                 Model.TextDocument = null;
             }));
-
-            AddWatchCommand = ReactiveCommand.Create();
+            
+            AddWatchCommand = ReactiveCommand.Create(this.WhenAny(x=>x.WordAtCaret, (word) => !string.IsNullOrEmpty(word.Value)));
             disposables.Add(AddWatchCommand.Subscribe(_ => { IoC.Get<IWatchList>()?.AddWatch(WordAtCaret); }));
 
             tabCharacter = "    ";

--- a/AvalonStudio/AvalonStudio/Controls/PackageManagerDialogViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/PackageManagerDialogViewModel.cs
@@ -51,7 +51,7 @@ namespace AvalonStudio.Controls
             InstallCommand = ReactiveCommand.Create();
             InstallCommand.Subscribe(async _ =>
             {
-                await _packageManager.InstallPackage(selectedPackage.Identity.Id, selectedPackage.Identity.Version.ToFullString());
+                await PackageManager.InstallPackage(selectedPackage.Identity.Id, selectedPackage.Identity.Version.ToFullString());
 
                 InvalidateInstalledPackages();
             });
@@ -61,7 +61,7 @@ namespace AvalonStudio.Controls
             {
                 if (SelectedInstalledPackage != null)
                 {
-                    await _packageManager.UninstallPackage(SelectedInstalledPackage.Model.Id, SelectedInstalledPackage.Model.Version.ToNormalizedString());
+                    await PackageManager.UninstallPackage(SelectedInstalledPackage.Model.Id, SelectedInstalledPackage.Model.Version.ToNormalizedString());
 
                     InvalidateInstalledPackages();
                 }

--- a/AvalonStudio/AvalonStudio/Controls/PackageManagerDialogViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/PackageManagerDialogViewModel.cs
@@ -175,7 +175,6 @@ namespace AvalonStudio.Controls
             set { this.RaiseAndSetIfChanged(ref selectedInstalledPackage, value); }
         }
 
-
         public ReactiveCommand<object> InstallCommand { get; }
         public ReactiveCommand<object> UninstallCommand { get; }
         public override ReactiveCommand<object> OKCommand { get; protected set; }

--- a/AvalonStudio/AvalonStudio/Controls/PackageManagerDialogViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/PackageManagerDialogViewModel.cs
@@ -214,7 +214,7 @@ namespace AvalonStudio.Controls
         {
             var packages = await _packageManager.ListPackages(100);
 
-            foreach (var package in packages.Where(p=>p.Title.EndsWith(Platform.AvalonRID)))
+            foreach (var package in packages.Where(p => p.Title.EndsWith(Platform.AvalonRID)))
             {
                 availablePackages.Add(package);
             }

--- a/AvalonStudio/AvalonStudio/Controls/PackageManagerDialogViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/PackageManagerDialogViewModel.cs
@@ -2,6 +2,7 @@ using Avalonia.Threading;
 using AvalonStudio.Extensibility.Dialogs;
 using AvalonStudio.MVVM;
 using AvalonStudio.Packages;
+using AvalonStudio.Platforms;
 using AvalonStudio.Utils;
 using NuGet.Common;
 using NuGet.Protocol.Core.Types;
@@ -30,7 +31,7 @@ namespace AvalonStudio.Controls
 
         private void InvalidateInstalledPackages()
         {
-            InstalledPackages = new ObservableCollection<PackageIdentityViewModel>(_packageManager.ListInstalledPackages().Select(pr => new PackageIdentityViewModel(pr)));
+            InstalledPackages = new ObservableCollection<PackageIdentityViewModel>(PackageManager.ListInstalledPackages().Select(pr => new PackageIdentityViewModel(pr)));
         }
 
         public PackageManagerDialogViewModel()
@@ -58,9 +59,12 @@ namespace AvalonStudio.Controls
             UninstallCommand = ReactiveCommand.Create();
             UninstallCommand.Subscribe(async _ =>
             {
-                await _packageManager.UninstallPackage(selectedPackage.Identity.Id, selectedPackage.Identity.Version.ToNormalizedString());
+                if (SelectedInstalledPackage != null)
+                {
+                    await _packageManager.UninstallPackage(SelectedInstalledPackage.Model.Id, SelectedInstalledPackage.Model.Version.ToNormalizedString());
 
-                InvalidateInstalledPackages();
+                    InvalidateInstalledPackages();
+                }
             });
 
             OKCommand = ReactiveCommand.Create(this.WhenAnyValue(x => x.EnableInterface));
@@ -163,6 +167,15 @@ namespace AvalonStudio.Controls
             set { this.RaiseAndSetIfChanged(ref installedPackages, value); }
         }
 
+        private PackageIdentityViewModel selectedInstalledPackage;
+
+        public PackageIdentityViewModel SelectedInstalledPackage
+        {
+            get { return selectedInstalledPackage; }
+            set { this.RaiseAndSetIfChanged(ref selectedInstalledPackage, value); }
+        }
+
+
         public ReactiveCommand<object> InstallCommand { get; }
         public ReactiveCommand<object> UninstallCommand { get; }
         public override ReactiveCommand<object> OKCommand { get; protected set; }
@@ -201,7 +214,7 @@ namespace AvalonStudio.Controls
         {
             var packages = await _packageManager.ListPackages(100);
 
-            foreach (var package in packages)
+            foreach (var package in packages.Where(p=>p.Title.EndsWith(Platform.AvalonRID)))
             {
                 availablePackages.Add(package);
             }

--- a/AvalonStudio/AvalonStudio/ShellViewModel.cs
+++ b/AvalonStudio/AvalonStudio/ShellViewModel.cs
@@ -236,7 +236,7 @@ namespace AvalonStudio
 
             StatusBar.LineNumber = 1;
             StatusBar.Column = 1;
-            StatusBar.PlatformString = Platform.OSDescription;
+            StatusBar.PlatformString = Platform.OSDescription + " " + Platform.AvalonRID;
 
             ProcessCancellationToken = new CancellationTokenSource();
 


### PR DESCRIPTION
- [ ] implement manual .nuget restore option.

- [x] implement watchpoints (http://davis.lbl.gov/Manuals/GDB/gdb_24.html#SEC244)

- [ ] Add a breakpoints window to allow managing of breakpoints including watchpoints and conditionals.

- [x] Fix expression resolving in c# debugger.

- [x] Implement auto install of required packages.

- [ ] Make breakpoints line number get updated as editor inserts text above it.

 - [ ] implement Linux / mac compatibility.

- [ ] Implement registers (need to extend gdb session class for this)

- [x] implement call stack

- [ ] implement disassembly window (should have its source data abstracted)

- [ ] implement console and debug output redirection to Shells console.

- [ ] run to this line

- [ ] is edit and go possible?

- [ ] add mono debugger unit tests.

- [ ] get mono debugger libs PRed to mono repo.

- [ ] migrate directly to roslyn workspaces for project support

- [x] implement resolve .net core dbfshim paths.

- [ ] DOTNET_SKIP_FIRST_TIME_EXPERIENCE=1 to prevent seeing expanding cache screen.