### PR TITLE
allow unresolved references without loosing the reference when opened.

### DIFF
--- a/AvalonStudio/AvalonStudio.Extensibility/Projects/UnresolvedReference.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Projects/UnresolvedReference.cs
@@ -1,0 +1,110 @@
+﻿namespace AvalonStudio.Projects
+{
+    using AvalonStudio.Debugging;
+    using AvalonStudio.TestFrameworks;
+    using AvalonStudio.Toolchains;
+    using System;
+    using System.Collections.Generic;
+    using System.Collections.ObjectModel;
+    using System.IO;
+
+    public class UnresolvedReference : IProject
+    {
+        public UnresolvedReference(ISolution solution, string location)
+        {
+            Location = location;
+        }
+
+        public ISolution Solution {get; set;}
+
+        public ObservableCollection<IProject> References => null;
+
+        public IToolChain ToolChain { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public IDebugger Debugger2 { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public ITestFramework TestFramework { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public bool Hidden { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public string CurrentDirectory => throw new NotImplementedException();
+
+        public IList<object> ConfigurationPages => throw new NotImplementedException();
+
+        public string Executable { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public dynamic ToolchainSettings => throw new NotImplementedException();
+
+        public dynamic DebugSettings => throw new NotImplementedException();
+
+        public dynamic Settings => throw new NotImplementedException();
+
+        public ObservableCollection<IProjectItem> Items => throw new NotImplementedException();
+
+        public string Location {get; set;}
+
+        public string LocationDirectory => throw new NotImplementedException();
+
+        public string Name
+        {
+            get { return Path.GetFileNameWithoutExtension(Location); }
+        }
+
+        public IProject Project { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+        public IProjectFolder Parent { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
+
+        public event EventHandler FileAdded;
+
+        public void AddReference(IProject project)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int CompareTo(IProjectItem other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int CompareTo(IProjectFolder other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int CompareTo(string other)
+        {
+            throw new NotImplementedException();
+        }
+
+        public int CompareTo(IProject other)
+        {
+            return Name.CompareTo(other.Name);
+        }
+
+        public void ExcludeFile(ISourceFile file)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ExcludeFolder(IProjectFolder folder)
+        {
+            throw new NotImplementedException();
+        }
+
+        public ISourceFile FindFile(string path)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void RemoveReference(IProject project)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void ResolveReferences()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Save()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/AvalonStudio/AvalonStudio.Extensibility/Shell/FileOpenedEventArgs.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Shell/FileOpenedEventArgs.cs
@@ -1,0 +1,12 @@
+﻿using AvalonStudio.Documents;
+using AvalonStudio.Projects;
+using System;
+
+namespace AvalonStudio.Shell
+{
+    public class FileOpenedEventArgs : EventArgs
+    {
+        public ISourceFile File { get; set; }
+        public IEditor Editor { get; set; }
+    }
+}

--- a/AvalonStudio/AvalonStudio.MiniShell/MinimalShell.cs
+++ b/AvalonStudio/AvalonStudio.MiniShell/MinimalShell.cs
@@ -29,6 +29,9 @@ namespace AvalonStudio.Shell
         private List<IDebugger> _debugger2s;
         private List<ITestFramework> _testFrameworks;
 
+        public event EventHandler<FileOpenedEventArgs> FileOpened;
+        public event EventHandler<FileOpenedEventArgs> FileClosed;
+
         [ImportingConstructor]
         public MinimalShell([ImportMany] IEnumerable<IExtension> extensions)
         {
@@ -223,6 +226,11 @@ namespace AvalonStudio.Shell
         }
 
         public void InvalidateErrors()
+        {
+            throw new NotImplementedException();
+        }
+
+        public void CloseDocument(ISourceFile file)
         {
             throw new NotImplementedException();
         }

--- a/AvalonStudio/AvalonStudio.Projects.CPlusPlus/CPlusPlusProject.cs
+++ b/AvalonStudio/AvalonStudio.Projects.CPlusPlus/CPlusPlusProject.cs
@@ -69,7 +69,7 @@ namespace AvalonStudio.Projects.CPlusPlus
         [JsonProperty(PropertyName = "Toolchain")]
         public string ToolchainReference { get; set; }
 
-        public string ToolchainVersion {get; set;}
+        public string ToolchainVersion { get; set; }
 
         [JsonProperty(PropertyName = "Debugger")]
         public string DebuggerReference { get; set; }
@@ -140,7 +140,7 @@ namespace AvalonStudio.Projects.CPlusPlus
                 }
                 else
                 {
-                    Console.WriteLine("Implement placeholder reference here.");
+                    AddReference(new UnresolvedReference(Solution, Path.Combine(Solution.Location, reference.Name)));
                 }
             }
         }
@@ -153,7 +153,10 @@ namespace AvalonStudio.Projects.CPlusPlus
             {
                 var standardReference = reference as CPlusPlusProject;
 
-                result.AddRange(standardReference.GenerateReferencedIncludes());
+                if (standardReference != null)
+                {
+                    result.AddRange(standardReference.GenerateReferencedIncludes());
+                }
             }
 
             return result;
@@ -167,7 +170,10 @@ namespace AvalonStudio.Projects.CPlusPlus
             {
                 var standardReference = reference as CPlusPlusProject;
 
-                result.AddRange(standardReference.GenerateReferencedDefines());
+                if (standardReference != null)
+                {
+                    result.AddRange(standardReference.GenerateReferencedDefines());
+                }
             }
 
             return result;
@@ -181,7 +187,10 @@ namespace AvalonStudio.Projects.CPlusPlus
             {
                 var standardReference = reference as CPlusPlusProject;
 
-                result.AddRange(standardReference.GetGlobalIncludes());
+                if (standardReference != null)
+                {
+                    result.AddRange(standardReference.GetGlobalIncludes());
+                }
             }
 
             foreach (var include in Includes.Where(i => i.Global))
@@ -200,7 +209,10 @@ namespace AvalonStudio.Projects.CPlusPlus
             {
                 var standardReference = reference as CPlusPlusProject;
 
-                result.AddRange(standardReference.GetGlobalDefines());
+                if (standardReference != null)
+                {
+                    result.AddRange(standardReference.GetGlobalDefines());
+                }
             }
 
             foreach (var define in Defines.Where(i => i.Global))
@@ -468,13 +480,10 @@ namespace AvalonStudio.Projects.CPlusPlus
             {
                 var loadedReference = reference as CPlusPlusProject;
 
-                if (loadedReference == null)
+                if (loadedReference != null)
                 {
-                    // What to do in this situation?
-                    throw new NotImplementedException();
+                    result.AddRange(loadedReference.GenerateReferencedIncludes());
                 }
-
-                result.AddRange(loadedReference.GenerateReferencedIncludes());
             }
 
             foreach (var includePath in Includes.Where(i => i.Exported && !i.Global))
@@ -500,13 +509,10 @@ namespace AvalonStudio.Projects.CPlusPlus
             {
                 var loadedReference = reference as CPlusPlusProject;
 
-                if (loadedReference == null)
+                if (loadedReference != null)
                 {
-                    // What to do in this situation?
-                    throw new NotImplementedException();
+                    result.AddRange(loadedReference.GenerateReferencedDefines());
                 }
-
-                result.AddRange(loadedReference.GenerateReferencedDefines());
             }
 
             foreach (var define in Defines.Where(i => i.Exported && !i.Global))


### PR DESCRIPTION
minimal sheel fixed.

cpp code completion only contains available completions.

dispose in thread-safe manor translation unit.