### PR TITLE
Fix document tab control

### DIFF
--- a/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/CodeEditor.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/CodeEditor.cs
@@ -260,9 +260,9 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
 
                     _isLoaded = true;
 
-                    TextArea.TextView.Redraw();
-
                     RegisterLanguageService(file.Item2);
+
+                    TextArea.TextView.Redraw();                    
                 }
             });
 

--- a/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/CodeEditor.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/CodeEditor.cs
@@ -243,24 +243,27 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
                 await DoCodeAnalysisAsync();
             });
 
-            this.GetObservable(SourceFileProperty).OfType<ISourceFile>().Subscribe(file =>
+            this.GetObservableWithHistory(SourceFileProperty).Subscribe((file) =>
             {
-                if (System.IO.File.Exists(file.Location))
+                if (file.Item1 != file.Item2)
                 {
-                    using (var fs = System.IO.File.OpenText(file.Location))
+                    if (System.IO.File.Exists(file.Item2.Location))
                     {
-                        Document = new TextDocument(fs.ReadToEnd())
+                        using (var fs = System.IO.File.OpenText(file.Item2.Location))
                         {
-                            FileName = file.Location
-                        };
+                            Document = new TextDocument(fs.ReadToEnd())
+                            {
+                                FileName = file.Item2.Location
+                            };
+                        }
                     }
+
+                    _isLoaded = true;
+
+                    TextArea.TextView.Redraw();
+
+                    RegisterLanguageService(file.Item2);
                 }
-
-                _isLoaded = true;
-
-                TextArea.TextView.Redraw();
-
-                RegisterLanguageService(file);
             });
 
             TextArea.TextEntering += (sender, e) =>

--- a/AvalonStudio/AvalonStudio.Controls.Standard/SolutionExplorer/SolutionExplorerViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/SolutionExplorer/SolutionExplorerViewModel.cs
@@ -96,9 +96,7 @@ namespace AvalonStudio.Controls.Standard.SolutionExplorer
 
                 if (value is SourceFileViewModel)
                 {
-                    // might need wait here?
-                    Task.Factory.StartNew(
-                        async () => { await shell.OpenDocument((ISourceFile)(value as SourceFileViewModel).Model, 1); });
+                    shell.OpenDocument((ISourceFile)(value as SourceFileViewModel).Model, 1);
                 }
             }
         }

--- a/AvalonStudio/AvalonStudio.Extensibility/AvalonStudio.Extensibility.csproj
+++ b/AvalonStudio/AvalonStudio.Extensibility/AvalonStudio.Extensibility.csproj
@@ -8,12 +8,16 @@
   </ItemGroup>
   <ItemGroup>
     <None Remove="Controls\ControlTheme.paml" />
+    <None Remove="Controls\DocumentTabControl.xaml" />
+    <None Remove="Controls\DocumentTabItem.xaml" />
     <None Remove="Controls\ToolControl.paml" />
     <None Remove="Controls\ViewModelViewHost.xaml" />
     <None Remove="MainMenu\ViewModels\MainMenuView.paml" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Controls\ControlTheme.paml" />
+    <EmbeddedResource Include="Controls\DocumentTabControl.xaml" />
+    <EmbeddedResource Include="Controls\DocumentTabItem.xaml" />
     <EmbeddedResource Include="Controls\ToolControl.paml" />
     <EmbeddedResource Include="Controls\ViewModelViewHost.xaml" />
     <EmbeddedResource Include="MainMenu\ViewModels\MainMenuView.paml" />

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/ControlTheme.paml
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/ControlTheme.paml
@@ -1,4 +1,6 @@
 ﻿<Styles xmlns="https://github.com/avaloniaui">
   <StyleInclude Source="resm:AvalonStudio.Extensibility.Controls.ToolControl.paml?assembly=AvalonStudio.Extensibility"/>
+  <StyleInclude Source="resm:AvalonStudio.Extensibility.Controls.DocumentTabControl.xaml?assembly=AvalonStudio.Extensibility"/>
+  <StyleInclude Source="resm:AvalonStudio.Extensibility.Controls.DocumentTabItem.xaml?assembly=AvalonStudio.Extensibility"/>
   <StyleInclude Source="resm:AvalonStudio.Extensibility.Controls.ViewModelViewHost.xaml?assembly=AvalonStudio.Extensibility"/>
 </Styles>

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.cs
@@ -13,8 +13,10 @@ namespace AvalonStudio.Controls
     {
         public DocumentTabControl()
         {
-            SelectionMode = SelectionMode.AlwaysSelected;
+            SelectionMode = SelectionMode.AlwaysSelected;            
         }
+
+        private ContentControl _seperator;
 
         /// <summary>
         /// Defines an <see cref="IMemberSelector"/> that selects the content of a <see cref="TabItem"/>.
@@ -38,14 +40,38 @@ namespace AvalonStudio.Controls
             set { SetValue(HeaderTemplateProperty, value); }
         }
 
+        private void InvalidateSeperatorVisiblity()
+        {
+            if (_seperator != null)
+            {
+                if (Items.Count() == 0)
+                {
+                    _seperator.IsVisible = false;
+                }
+                else
+                {
+                    _seperator.IsVisible = true;
+                }
+            }
+        }
+
+        protected override void ItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+        {
+            base.ItemsCollectionChanged(sender, e);
+
+            InvalidateSeperatorVisiblity();
+        }
+
         protected override void ItemsChanged(AvaloniaPropertyChangedEventArgs e)
         {
             base.ItemsChanged(e);
 
             if (Items.Count() > 0)
-            {
+            {                
                 SelectedIndex = 0;
             }
+
+            InvalidateSeperatorVisiblity();
         }
 
         /// <summary>
@@ -77,6 +103,8 @@ namespace AvalonStudio.Controls
             {
                 carousel.MemberSelector = ContentSelector;
             }
+
+            _seperator = e.NameScope.Find<ContentControl>("PART_Seperator");
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.cs
@@ -11,11 +11,6 @@ namespace AvalonStudio.Controls
 {
     public class DocumentTabControl : SelectingItemsControl
     {
-        static DocumentTabControl()
-        {
-
-        }
-
         public DocumentTabControl()
         {
             SelectionMode = SelectionMode.AlwaysSelected;
@@ -41,10 +36,10 @@ namespace AvalonStudio.Controls
         {
             get { return GetValue(HeaderTemplateProperty); }
             set { SetValue(HeaderTemplateProperty, value); }
-        }        
+        }
 
         protected override void ItemsChanged(AvaloniaPropertyChangedEventArgs e)
-        {            
+        {
             base.ItemsChanged(e);
 
             if (Items.Count() > 0)
@@ -78,8 +73,8 @@ namespace AvalonStudio.Controls
 
             var carousel = e.NameScope.Find<Carousel>("PART_Carousel");
 
-            if(carousel != null)
-            {               
+            if (carousel != null)
+            {
                 carousel.MemberSelector = ContentSelector;
             }
         }

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.cs
@@ -14,9 +14,7 @@ namespace AvalonStudio.Controls
         public DocumentTabControl()
         {
             SelectionMode = SelectionMode.AlwaysSelected;            
-        }
-
-        private ContentControl _seperator;
+        }        
 
         /// <summary>
         /// Defines an <see cref="IMemberSelector"/> that selects the content of a <see cref="TabItem"/>.
@@ -38,28 +36,11 @@ namespace AvalonStudio.Controls
         {
             get { return GetValue(HeaderTemplateProperty); }
             set { SetValue(HeaderTemplateProperty, value); }
-        }        
-
-        private void InvalidateSeperatorVisiblity()
-        {
-            if (_seperator != null)
-            {
-                if (Items.Count() == 0)
-                {
-                    _seperator.IsVisible = false;
-                }
-                else
-                {
-                    _seperator.IsVisible = true;
-                }
-            }
-        }
+        }                
 
         protected override void ItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
         {
             base.ItemsCollectionChanged(sender, e);
-
-            InvalidateSeperatorVisiblity();
         }
 
         protected override void ItemsChanged(AvaloniaPropertyChangedEventArgs e)
@@ -70,8 +51,6 @@ namespace AvalonStudio.Controls
             {                
                 SelectedIndex = 0;
             }
-
-            InvalidateSeperatorVisiblity();
         }
 
         /// <summary>
@@ -103,8 +82,6 @@ namespace AvalonStudio.Controls
             {
                 carousel.MemberSelector = ContentSelector;
             }
-
-            _seperator = e.NameScope.Find<ContentControl>("PART_Seperator");
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.cs
@@ -1,0 +1,87 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
+using Avalonia.Controls.Templates;
+using System.Collections.Specialized;
+using System.Linq;
+using Avalonia.LogicalTree;
+using AvalonStudio.Utils;
+
+namespace AvalonStudio.Controls
+{
+    public class DocumentTabControl : SelectingItemsControl
+    {
+        static DocumentTabControl()
+        {
+
+        }
+
+        public DocumentTabControl()
+        {
+            SelectionMode = SelectionMode.AlwaysSelected;
+        }
+
+        /// <summary>
+        /// Defines an <see cref="IMemberSelector"/> that selects the content of a <see cref="TabItem"/>.
+        /// </summary>
+        public static readonly IMemberSelector ContentSelector =
+            new FuncMemberSelector<object, object>(SelectContent);
+
+        public static readonly StyledProperty<object> HeaderSeperatorContentProperty = AvaloniaProperty.Register<DocumentTabControl, object>(nameof(HeaderSeperatorContent));
+
+        public object HeaderSeperatorContent
+        {
+            get { return GetValue(HeaderSeperatorContentProperty); }
+            set { SetValue(HeaderSeperatorContentProperty, value); }
+        }
+
+        public static readonly StyledProperty<IDataTemplate> HeaderTemplateProperty = AvaloniaProperty.Register<DocumentTabControl, IDataTemplate>(nameof(HeaderTemplate));
+
+        public IDataTemplate HeaderTemplate
+        {
+            get { return GetValue(HeaderTemplateProperty); }
+            set { SetValue(HeaderTemplateProperty, value); }
+        }
+
+        protected override void ItemsChanged(AvaloniaPropertyChangedEventArgs e)
+        {            
+            base.ItemsChanged(e);
+
+            if (Items.Count() > 0)
+            {
+                SelectedIndex = 0;
+            }
+        }
+
+        /// <summary>
+        /// Selects the content of a tab item.
+        /// </summary>
+        /// <param name="o">The tab item.</param>
+        /// <returns>The content.</returns>
+        private static object SelectContent(object o)
+        {
+            var content = o as IContentControl;
+
+            if (content != null)
+            {
+                return content.Content;
+            }
+            else
+            {
+                return o;
+            }
+        }
+
+        protected override void OnTemplateApplied(TemplateAppliedEventArgs e)
+        {
+            base.OnTemplateApplied(e);
+
+            var carousel = e.NameScope.Find<Carousel>("PART_Carousel");
+
+            if(carousel != null)
+            {
+                carousel.MemberSelector = ContentSelector;
+            }
+        }
+    }
+}

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.cs
@@ -38,7 +38,7 @@ namespace AvalonStudio.Controls
         {
             get { return GetValue(HeaderTemplateProperty); }
             set { SetValue(HeaderTemplateProperty, value); }
-        }
+        }        
 
         private void InvalidateSeperatorVisiblity()
         {

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.cs
@@ -41,7 +41,7 @@ namespace AvalonStudio.Controls
         {
             get { return GetValue(HeaderTemplateProperty); }
             set { SetValue(HeaderTemplateProperty, value); }
-        }
+        }        
 
         protected override void ItemsChanged(AvaloniaPropertyChangedEventArgs e)
         {            
@@ -79,7 +79,7 @@ namespace AvalonStudio.Controls
             var carousel = e.NameScope.Find<Carousel>("PART_Carousel");
 
             if(carousel != null)
-            {
+            {               
                 carousel.MemberSelector = ContentSelector;
             }
         }

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.xaml
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.xaml
@@ -20,7 +20,7 @@
                             </TabStrip.ItemsPanel>
                         </TabStrip>
 
-                        <ContentControl Content="{TemplateBinding HeaderSeperatorContent}" Name="PART_Seperator" />
+                        <ContentControl Content="{TemplateBinding HeaderSeperatorContent}" IsVisible="{TemplateBinding HeaderSeperatorVisible}" />
                     </StackPanel>
 
                     <Carousel Name="PART_Carousel"  Items="{TemplateBinding Items}" SelectedIndex="{TemplateBinding Path=SelectedIndex}" IsVirtualized="false" ItemTemplate="{TemplateBinding ItemTemplate}" />

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.xaml
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.xaml
@@ -1,0 +1,26 @@
+﻿<Styles xmlns:local="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio.Extensibility" xmlns="https://github.com/avaloniaui">
+    <Style Selector="local|DocumentTabControl">
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="0"/>
+        <Setter Property="Focusable" Value="True" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <DockPanel>
+                    <StackPanel DockPanel.Dock="Top">
+                        <TabStrip Name="strip"  Items="{TemplateBinding Items}"  SelectedIndex="{TemplateBinding SelectedIndex, Mode=TwoWay}" ItemTemplate="{TemplateBinding HeaderTemplate}">
+                            <TabStrip.ItemsPanel>
+                                <ItemsPanelTemplate>
+                                    <DockPanel  LastChildFill="false" />
+                                </ItemsPanelTemplate>
+                            </TabStrip.ItemsPanel>
+                        </TabStrip>
+
+                        <ContentControl Content="{TemplateBinding HeaderSeperatorContent}" />
+                    </StackPanel>
+
+                    <Carousel Name="PART_Carousel"  Items="{TemplateBinding Items}" SelectedIndex="{TemplateBinding Path=SelectedIndex}" IsVirtualized="false" />
+                </DockPanel>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+</Styles>

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.xaml
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.xaml
@@ -8,6 +8,11 @@
                 <DockPanel>
                     <StackPanel DockPanel.Dock="Top">
                         <TabStrip Name="strip"  Items="{TemplateBinding Items}"  SelectedIndex="{TemplateBinding SelectedIndex, Mode=TwoWay}" ItemTemplate="{TemplateBinding HeaderTemplate}">
+                            <TabStrip.Styles>
+                                <Style Selector="TabStripItem">
+                                    <Setter Property="DockPanel.Dock" Value="{Binding Dock}" />
+                                </Style>
+                            </TabStrip.Styles>
                             <TabStrip.ItemsPanel>
                                 <ItemsPanelTemplate>
                                     <DockPanel  LastChildFill="false" />

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.xaml
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.xaml
@@ -20,7 +20,7 @@
                             </TabStrip.ItemsPanel>
                         </TabStrip>
 
-                        <ContentControl Content="{TemplateBinding HeaderSeperatorContent}" />
+                        <ContentControl Content="{TemplateBinding HeaderSeperatorContent}" Name="PART_Seperator" />
                     </StackPanel>
 
                     <Carousel Name="PART_Carousel"  Items="{TemplateBinding Items}" SelectedIndex="{TemplateBinding Path=SelectedIndex}" IsVirtualized="false" ItemTemplate="{TemplateBinding ItemTemplate}" />

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.xaml
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabControl.xaml
@@ -18,7 +18,7 @@
                         <ContentControl Content="{TemplateBinding HeaderSeperatorContent}" />
                     </StackPanel>
 
-                    <Carousel Name="PART_Carousel"  Items="{TemplateBinding Items}" SelectedIndex="{TemplateBinding Path=SelectedIndex}" IsVirtualized="false" />
+                    <Carousel Name="PART_Carousel"  Items="{TemplateBinding Items}" SelectedIndex="{TemplateBinding Path=SelectedIndex}" IsVirtualized="false" ItemTemplate="{TemplateBinding ItemTemplate}" />
                 </DockPanel>
             </ControlTemplate>
         </Setter>

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabItem.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabItem.cs
@@ -10,6 +10,10 @@ namespace AvalonStudio.Controls
         static DocumentTabItem()
         {
             PseudoClass(IsFocusedProperty, o => o, ":focused");
+            PseudoClass(DockPanel.DockProperty, o => o == Dock.Right, ":dockright");
+            PseudoClass(DockPanel.DockProperty, o => o == Dock.Left, ":dockleft");
+            PseudoClass(DockPanel.DockProperty, o => o == Dock.Top, ":docktop");
+            PseudoClass(DockPanel.DockProperty, o => o == Dock.Bottom, ":dockbottom");
         }
 
         public static readonly AvaloniaProperty<string> TitleProprty =

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabItem.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabItem.cs
@@ -1,0 +1,33 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Media;
+
+namespace AvalonStudio.Controls
+{
+    public class DocumentTabItem : ContentControl
+    {
+        static DocumentTabItem()
+        {
+            PseudoClass(IsFocusedProperty, o => o, ":focused");
+        }
+
+        public static readonly AvaloniaProperty<string> TitleProprty =
+            AvaloniaProperty.Register<ToolControl, string>(nameof(Title));
+
+        public string Title
+        {
+            get { return GetValue(TitleProprty); }
+            set { SetValue(TitleProprty, value); }
+        }
+
+        public static readonly AvaloniaProperty<IBrush> HeaderBackgroundProperty =
+            AvaloniaProperty.Register<ToolControl, IBrush>(nameof(HeaderBackground), defaultValue: Brushes.WhiteSmoke);
+
+        public IBrush HeaderBackground
+        {
+            get { return GetValue(HeaderBackgroundProperty); }
+            set { SetValue(HeaderBackgroundProperty, value); }
+        }
+    }
+}

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabItem.xaml
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/DocumentTabItem.xaml
@@ -1,0 +1,21 @@
+﻿<Styles xmlns:local="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio.Extensibility" xmlns="https://github.com/avaloniaui">
+    <Style Selector="local|DocumentTabItem">
+        <Setter Property="BorderThickness" Value="0"/>
+        <Setter Property="Padding" Value="0"/>
+        <Setter Property="Focusable" Value="True" />
+        <Setter Property="Template">
+            <ControlTemplate>
+                <Border BorderThickness="1" BorderBrush="{StyleResource ApplicationBorderBrush}" Background="{StyleResource ControlBackgroundBrush}">
+                    <Grid Margin="4">
+                        <ContentPresenter  Grid.Row="1" Name="PART_ContentPresenter"
+                         Background="{TemplateBinding Background}"
+                         BorderBrush="{TemplateBinding BorderBrush}"
+                         BorderThickness="{TemplateBinding BorderThickness}"
+                         Content="{TemplateBinding Content}"
+                         Padding="{TemplateBinding Padding}"/>
+                    </Grid>
+                </Border>
+            </ControlTemplate>
+        </Setter>
+    </Style>
+</Styles>

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/GenericDocumentTabViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/GenericDocumentTabViewModel.cs
@@ -64,5 +64,19 @@ namespace AvalonStudio.Controls
                 this.RaisePropertyChanged(nameof(Title));
             }
         }
+
+        private bool _isTemporary;
+
+        public bool IsTemporary
+        {
+            get
+            {
+                return _isTemporary;
+            }
+            set
+            {
+                this.RaiseAndSetIfChanged(ref _isTemporary, value);
+            }
+        }
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/GenericDocumentTabViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/GenericDocumentTabViewModel.cs
@@ -17,6 +17,8 @@ namespace AvalonStudio.Controls
             {
                 IoC.Get<IShell>().RemoveDocument(this);
             });
+
+            IsVisible = true;
         }
 
         private Dock dock;
@@ -77,6 +79,19 @@ namespace AvalonStudio.Controls
             {
                 this.RaiseAndSetIfChanged(ref _isTemporary, value);
             }
+        }
+
+        private bool _isHidden;
+
+        public bool IsVisible
+        {
+            get { return _isHidden; }
+            set { this.RaiseAndSetIfChanged(ref _isHidden, value); }
+        }
+
+        public virtual void OnClose()
+        {
+            
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/GenericDocumentTabViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/GenericDocumentTabViewModel.cs
@@ -91,7 +91,6 @@ namespace AvalonStudio.Controls
 
         public virtual void OnClose()
         {
-            
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/IDocumentTabViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/IDocumentTabViewModel.cs
@@ -13,6 +13,10 @@ namespace AvalonStudio.Controls
 
         bool IsTemporary { get; set; }
 
+        bool IsVisible { get; set; }
+
         Dock Dock { get; set; }
+
+        void OnClose();
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/IDocumentTabViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/IDocumentTabViewModel.cs
@@ -11,6 +11,8 @@ namespace AvalonStudio.Controls
 
         ReactiveCommand<object> CloseCommand { get; }
 
+        bool IsTemporary { get; set; }
+
         Dock Dock { get; set; }
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/IEditor.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/IEditor.cs
@@ -8,6 +8,10 @@ namespace AvalonStudio.Documents
     {
         ISourceFile ProjectFile { get; }
 
+        void Focus();
+
+        void TriggerCodeAnalysis();
+
         void Close();
 
         void Save();

--- a/AvalonStudio/AvalonStudio.Extensibility/Utils/IEnumerableUtils.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Utils/IEnumerableUtils.cs
@@ -80,5 +80,4 @@ namespace AvalonStudio.Utils
             }
         }
     }
-
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Utils/IEnumerableUtils.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Utils/IEnumerableUtils.cs
@@ -36,6 +36,18 @@ namespace AvalonStudio.Utils
             }
         }
 
+        public static int Count(this IEnumerable items, Func<object, bool> predicate)
+        {
+            if (items != null)
+            {
+                return Enumerable.Count(items.Cast<object>(), predicate);                
+            }
+            else
+            {
+                return 0;
+            }
+        }
+
         public static int IndexOf(this IEnumerable items, object item)
         {
             Contract.Requires<ArgumentNullException>(items != null);

--- a/AvalonStudio/AvalonStudio.Extensibility/Utils/IEnumerableUtils.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Utils/IEnumerableUtils.cs
@@ -1,0 +1,84 @@
+﻿using Avalonia;
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace AvalonStudio.Utils
+{
+    internal static class IEnumerableUtils
+    {
+        public static bool Contains(this IEnumerable items, object item)
+        {
+            return items.IndexOf(item) != -1;
+        }
+
+        public static int Count(this IEnumerable items)
+        {
+            if (items != null)
+            {
+                var collection = items as ICollection;
+
+                if (collection != null)
+                {
+                    return collection.Count;
+                }
+                else
+                {
+                    return Enumerable.Count(items.Cast<object>());
+                }
+            }
+            else
+            {
+                return 0;
+            }
+        }
+
+        public static int IndexOf(this IEnumerable items, object item)
+        {
+            Contract.Requires<ArgumentNullException>(items != null);
+
+            var list = items as IList;
+
+            if (list != null)
+            {
+                return list.IndexOf(item);
+            }
+            else
+            {
+                int index = 0;
+
+                foreach (var i in items)
+                {
+                    if (ReferenceEquals(i, item))
+                    {
+                        return index;
+                    }
+
+                    ++index;
+                }
+
+                return -1;
+            }
+        }
+
+        public static object ElementAt(this IEnumerable items, int index)
+        {
+            Contract.Requires<ArgumentNullException>(items != null);
+
+            var list = items as IList;
+
+            if (list != null)
+            {
+                return list[index];
+            }
+            else
+            {
+                return Enumerable.ElementAt(items.Cast<object>(), index);
+            }
+        }
+    }
+
+}

--- a/AvalonStudio/AvalonStudio.Languages.CPlusPlus/CPlusPlusLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.CPlusPlus/CPlusPlusLanguageService.cs
@@ -668,19 +668,22 @@ namespace AvalonStudio.Languages.CPlusPlus
             {
                 var tu = GetAndParseTranslationUnit(file, clangUnsavedFiles);
 
-                var cursor = tu.GetCursor(tu.GetLocationForOffset(tu.GetFile(file.FilePath), offset));
-
-                switch (cursor.Kind)
+                if (tu != null)
                 {
-                    case NClang.CursorKind.MemberReferenceExpression:
-                    case NClang.CursorKind.DeclarationReferenceExpression:
-                    case NClang.CursorKind.CallExpression:
-                    case NClang.CursorKind.TypeReference:
-                        cursor = cursor.Referenced;
-                        break;
-                }
+                    var cursor = tu.GetCursor(tu.GetLocationForOffset(tu.GetFile(file.FilePath), offset));
 
-                result = SymbolFromClangCursor(cursor);
+                    switch (cursor.Kind)
+                    {
+                        case NClang.CursorKind.MemberReferenceExpression:
+                        case NClang.CursorKind.DeclarationReferenceExpression:
+                        case NClang.CursorKind.CallExpression:
+                        case NClang.CursorKind.TypeReference:
+                            cursor = cursor.Referenced;
+                            break;
+                    }
+
+                    result = SymbolFromClangCursor(cursor);
+                }
             });
 
             return result;

--- a/AvalonStudio/AvalonStudio/Controls/DocumentTabControl.paml
+++ b/AvalonStudio/AvalonStudio/Controls/DocumentTabControl.paml
@@ -1,81 +1,68 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:vm="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio"
              xmlns:cont="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio.Extensibility">
-  <DockPanel>
-    <StackPanel DockPanel.Dock="Top">
-      <TabStrip Name="strip"  Items="{Binding Documents}" SelectedItem="{Binding SelectedDocument, Mode=TwoWay}">
-        <TabStrip.ItemsPanel>
-          <ItemsPanelTemplate>
-            <DockPanel  LastChildFill="false" />
-          </ItemsPanelTemplate>  
-        </TabStrip.ItemsPanel>
-        
-        <TabStrip.Styles>
-          <Style Selector="TabStripItem">
-            <Setter Property="Height" Value="20" />
-            <Setter Property="Background" Value="#2D2D30" />
-            <Setter Property="BorderBrush" Value="#3E3E42" />
-            <Setter Property="BorderThickness" Value="0" />
-            <Setter Property="Margin" Value="0 0 0 -1" />
-            <Setter Property="Padding" Value="4 0 4 0" />
-            <Setter Property="FontSize" Value="12"/>
-            <Setter Property="DockPanel.Dock" Value="{Binding Dock}" />
-          </Style>
-          <Style Selector="TabStripItem:pointerover">
-            <Setter Property="Background" Value="#1c97ea" />
-          </Style>
-          <Style Selector="TabStripItem:selected">
-            <Setter Property="Background" Value="#007ACC" />
-          </Style>
-        </TabStrip.Styles>
+  <UserControl.Styles>
+    <Style Selector="cont|DocumentTabControl.documentTabControl /template/ TabStripItem">
+      <Setter Property="Height" Value="20" />
+      <Setter Property="Background" Value="{StyleResource ThemeBackgroundBrush}" />
+      <Setter Property="BorderThickness" Value="0" />
+      <Setter Property="Margin" Value="0 0 0 -1" />
+      <Setter Property="Padding" Value="4 0 4 0" />
+    </Style>
+    <Style Selector="cont|DocumentTabControl.documentTabControl /template/ TabStripItem:pointerover">
+      <Setter Property="Background" Value="{StyleResource ApplicationAccentBrushLight}" />
+      <Setter Property="Foreground" Value="{StyleResource ApplicationAccentForegroundBrush}" />
+    </Style>
+    <Style Selector="cont|DocumentTabControl.documentTabControl /template/ TabStripItem:selected">
+      <Setter Property="Background" Value="{StyleResource ApplicationAccentBrush}" />
+      <Setter Property="Foreground" Value="{StyleResource ApplicationAccentForegroundBrush}" />
+    </Style>
+  </UserControl.Styles>
+  <cont:DocumentTabControl Items="{Binding Documents}" SelectedItem="{Binding SelectedDocument, Mode=TwoWay}" Classes="documentTabControl">
+    <cont:DocumentTabControl.HeaderTemplate>
+      <DataTemplate>
+        <StackPanel Orientation="Horizontal" Gap="2">
+          <Button Height="14" Width="14" Command="{Binding CloseCommand}">
+            <Button.Styles>
+              <Style Selector="Button">
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="Padding" Value="0"/>
+                <Setter Property="Margin" Value="0"/>
+                <Setter Property="Background" Value="Transparent" />
+              </Style>
+              <Style Selector="Button:pointerover">
+                <Setter Property="Background" Value="#1c97ea" />
+              </Style>
+            </Button.Styles>
+            <Path Margin="2" Stretch="Uniform" UseLayoutRounding="False" Data="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" Fill="WhiteSmoke" />
+          </Button>
 
-        <TabStrip.ItemTemplate>
-          <DataTemplate>
-            <StackPanel Orientation="Horizontal" Gap="2">
-              <Button Height="14" Width="14" Command="{Binding CloseCommand}">
-                <Button.Styles>
-                  <Style Selector="Button">
-                    <Setter Property="BorderThickness" Value="0"/>
-                    <Setter Property="Padding" Value="0"/>
-                    <Setter Property="Margin" Value="0"/>
-                    <Setter Property="Background" Value="Transparent" />
-                  </Style>
-                  <Style Selector="Button:pointerover">
-                    <Setter Property="Background" Value="#1c97ea" />
-                  </Style>
-                </Button.Styles>
-                <Path Margin="2" Stretch="Uniform" UseLayoutRounding="False" Data="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" Fill="WhiteSmoke" />
-              </Button>
-              
-              <Button Height="14" Width="14">
-                <Button.Styles>
-                  <Style Selector="Button">
-                    <Setter Property="BorderThickness" Value="0"/>
-                    <Setter Property="Padding" Value="0"/>
-                    <Setter Property="Margin" Value="0"/>
-                    <Setter Property="Background" Value="Transparent" />
-                  </Style>
+          <Button Height="14" Width="14">
+            <Button.Styles>
+              <Style Selector="Button">
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="Padding" Value="0"/>
+                <Setter Property="Margin" Value="0"/>
+                <Setter Property="Background" Value="Transparent" />
+              </Style>
 
-                  <Style Selector="Button:pointerover">
-                    <Setter Property="Background" Value="#1c97ea" />
-                  </Style>
-                </Button.Styles>
-                <Path Margin="2" Stretch="Uniform" UseLayoutRounding="False" Data="M16,12V4H17V2H7V4H8V12L6,14V16H11.2V22H12.8V16H18V14L16,12Z" Fill="WhiteSmoke" />
-              </Button>
-              <TextBlock Text="{Binding Title}" Foreground="WhiteSmoke" Margin="2"/>              
-            </StackPanel>
-          </DataTemplate>
-        </TabStrip.ItemTemplate>
-      </TabStrip>
-      <Grid Background="#007ACC" Height="2" />
-    </StackPanel>
-
-    <Carousel Items="{Binding #strip.Items}" SelectedIndex="{Binding #strip.SelectedIndex}" IsVirtualized="false">
-      <Carousel.ItemTemplate>
-        <DataTemplate>
-          <cont:ViewModelViewHost IsVisible ="{Binding IsVisible}" />
-        </DataTemplate>
-      </Carousel.ItemTemplate>    
-    </Carousel>
-  </DockPanel>
+              <Style Selector="Button:pointerover">
+                <Setter Property="Background" Value="#1c97ea" />
+              </Style>
+            </Button.Styles>
+            <Path Margin="2" Stretch="Uniform" UseLayoutRounding="False" Data="M16,12V4H17V2H7V4H8V12L6,14V16H11.2V22H12.8V16H18V14L16,12Z" Fill="WhiteSmoke" />
+          </Button>
+          <TextBlock Text="{Binding Title}" Foreground="WhiteSmoke" Margin="2" FontSize="12"/>
+        </StackPanel>
+      </DataTemplate>
+    </cont:DocumentTabControl.HeaderTemplate>
+    <cont:DocumentTabControl.HeaderSeperatorContent>
+      <Grid Background="{StyleResource ApplicationAccentBrush}" Height="2" />
+    </cont:DocumentTabControl.HeaderSeperatorContent>
+    <cont:DocumentTabControl.ItemTemplate>
+      <DataTemplate>
+        <cont:ViewModelViewHost IsVisible ="{Binding IsVisible}" />
+      </DataTemplate>
+    </cont:DocumentTabControl.ItemTemplate>
+  </cont:DocumentTabControl>
 </UserControl>

--- a/AvalonStudio/AvalonStudio/Controls/DocumentTabControl.paml
+++ b/AvalonStudio/AvalonStudio/Controls/DocumentTabControl.paml
@@ -63,7 +63,7 @@
       </DataTemplate>
     </cont:DocumentTabControl.HeaderTemplate>
     <cont:DocumentTabControl.HeaderSeperatorContent>
-      <Grid Background="{StyleResource ApplicationAccentBrush}" Height="2" />
+      <Grid Background="{StyleResource ApplicationAccentBrush}" Height="2" IsVisible="{Binding SeperatorVisible}" />
     </cont:DocumentTabControl.HeaderSeperatorContent>
     <cont:DocumentTabControl.ItemTemplate>
       <DataTemplate>

--- a/AvalonStudio/AvalonStudio/Controls/DocumentTabControl.paml
+++ b/AvalonStudio/AvalonStudio/Controls/DocumentTabControl.paml
@@ -9,6 +9,7 @@
       <Setter Property="Margin" Value="0 0 0 -1" />
       <Setter Property="Padding" Value="4 0 4 0" />
       <Setter Property="Foreground" Value="{StyleResource ApplicationAccentForegroundBrush}" />
+      <Setter Property="IsVisible" Value="{Binding IsVisible}" />
     </Style>    
     <Style Selector="cont|DocumentTabControl /template/ TabStripItem:dockright:selected">
       <Setter Property="Background" Value="#68217A" />      

--- a/AvalonStudio/AvalonStudio/Controls/DocumentTabControl.paml
+++ b/AvalonStudio/AvalonStudio/Controls/DocumentTabControl.paml
@@ -2,23 +2,28 @@
              xmlns:vm="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio"
              xmlns:cont="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio.Extensibility">
   <UserControl.Styles>
-    <Style Selector="cont|DocumentTabControl.documentTabControl /template/ TabStripItem">
+    <Style Selector="cont|DocumentTabControl /template/ TabStripItem">
       <Setter Property="Height" Value="20" />
       <Setter Property="Background" Value="{StyleResource ThemeBackgroundBrush}" />
       <Setter Property="BorderThickness" Value="0" />
       <Setter Property="Margin" Value="0 0 0 -1" />
       <Setter Property="Padding" Value="4 0 4 0" />
+      <Setter Property="Foreground" Value="{StyleResource ApplicationAccentForegroundBrush}" />
+    </Style>    
+    <Style Selector="cont|DocumentTabControl /template/ TabStripItem:dockright:selected">
+      <Setter Property="Background" Value="#68217A" />      
     </Style>
-    <Style Selector="cont|DocumentTabControl.documentTabControl /template/ TabStripItem:pointerover">
+    <Style Selector="cont|DocumentTabControl /template/ TabStripItem:dockright:pointerover">
+      <Setter Property="Background" Value="#B064AB" />      
+    </Style>    
+    <Style Selector="cont|DocumentTabControl /template/ TabStripItem:dockleft:selected">
+      <Setter Property="Background" Value="{StyleResource ApplicationAccentBrush}" />      
+    </Style>
+    <Style Selector="cont|DocumentTabControl /template/ TabStripItem:dockleft:pointerover">
       <Setter Property="Background" Value="{StyleResource ApplicationAccentBrushLight}" />
-      <Setter Property="Foreground" Value="{StyleResource ApplicationAccentForegroundBrush}" />
-    </Style>
-    <Style Selector="cont|DocumentTabControl.documentTabControl /template/ TabStripItem:selected">
-      <Setter Property="Background" Value="{StyleResource ApplicationAccentBrush}" />
-      <Setter Property="Foreground" Value="{StyleResource ApplicationAccentForegroundBrush}" />
     </Style>
   </UserControl.Styles>
-  <cont:DocumentTabControl Items="{Binding Documents}" SelectedItem="{Binding SelectedDocument, Mode=TwoWay}" Classes="documentTabControl">
+  <cont:DocumentTabControl Items="{Binding Documents}" SelectedItem="{Binding SelectedDocument, Mode=TwoWay}">
     <cont:DocumentTabControl.HeaderTemplate>
       <DataTemplate>
         <StackPanel Orientation="Horizontal" Gap="2">

--- a/AvalonStudio/AvalonStudio/Controls/DocumentTabControlViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/DocumentTabControlViewModel.cs
@@ -68,12 +68,8 @@ namespace AvalonStudio.Controls
 
                 if (value is IEditor editor)
                 {
-                    // Dispatcher invoke is hack to make sure the Editor propery has been generated.
-                    
-                    {                        
-                        editor.Focus();
-                        editor.TriggerCodeAnalysis();
-                    }//);
+                    editor.Focus();
+                    editor.TriggerCodeAnalysis();
                 }
 
                 if (value == TemporaryDocument)

--- a/AvalonStudio/AvalonStudio/Controls/DocumentTabControlViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/DocumentTabControlViewModel.cs
@@ -7,6 +7,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace AvalonStudio.Controls
@@ -16,6 +17,7 @@ namespace AvalonStudio.Controls
         private ObservableCollection<IDocumentTabViewModel> documents;
         private List<IDocumentTabViewModel> cachedDocuments;
 
+        private bool _seperatorVisible;
         private IDocumentTabViewModel selectedDocument;
 
         public DocumentTabControlViewModel()
@@ -23,6 +25,24 @@ namespace AvalonStudio.Controls
             CachedDocuments = new List<IDocumentTabViewModel>();
 
             Documents = new ObservableCollection<IDocumentTabViewModel>();            
+        }        
+
+        public void InvalidateSeperatorVisibility()
+        {
+            if(Documents.Where(d=>d.IsVisible).Count() > 0)
+            {
+                SeperatorVisible = true;
+            }
+            else
+            {
+                SeperatorVisible = false;
+            }
+        }
+
+        public bool SeperatorVisible
+        {
+            get { return _seperatorVisible; }
+            set { this.RaiseAndSetIfChanged(ref _seperatorVisible, value); }
         }
 
         public List<IDocumentTabViewModel> CachedDocuments

--- a/AvalonStudio/AvalonStudio/Controls/DocumentTabControlViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/DocumentTabControlViewModel.cs
@@ -12,19 +12,9 @@ namespace AvalonStudio.Controls
 {
     public class DocumentTabControlViewModel : ViewModel
     {
-        private ObservableCollection<IDocumentTabViewModel> documents;
-
-        private IBrush hoverTabBackgroundBrush;
+        private ObservableCollection<IDocumentTabViewModel> documents;        
 
         private IDocumentTabViewModel selectedDocument;
-
-        private IBrush tabBackgroundBrush;
-        private IBrush tabBrush;
-        private readonly IBrush tabHighlightBrush;
-
-        private readonly IBrush temporaryTabBrush;
-
-        private readonly IBrush temporaryTabHighlighBrush;
 
         public DocumentTabControlViewModel()
         {
@@ -40,12 +30,6 @@ namespace AvalonStudio.Controls
                     });
                 }
             };
-
-            tabBrush = Brush.Parse("#007ACC");
-            tabHighlightBrush = Brush.Parse("#1c97ea");
-
-            temporaryTabBrush = Brush.Parse("#68217A");
-            temporaryTabHighlighBrush = Brush.Parse("#B064AB");
         }
 
         public ObservableCollection<IDocumentTabViewModel> Documents
@@ -71,32 +55,9 @@ namespace AvalonStudio.Controls
                     editor.Focus();
                     editor.TriggerCodeAnalysis();
                 }
-
-                if (value == TemporaryDocument)
-                {
-                    TabBackgroundBrush = temporaryTabBrush;
-                    HoverTabBackgroundBrush = temporaryTabHighlighBrush;
-                }
-                else
-                {
-                    TabBackgroundBrush = tabBackgroundBrush;
-                    HoverTabBackgroundBrush = tabHighlightBrush;
-                }
             }
         }
 
         public EditorViewModel TemporaryDocument { get; set; }
-
-        public IBrush TabBackgroundBrush
-        {
-            get { return tabBackgroundBrush; }
-            set { this.RaiseAndSetIfChanged(ref tabBackgroundBrush, value); }
-        }
-
-        public IBrush HoverTabBackgroundBrush
-        {
-            get { return hoverTabBackgroundBrush; }
-            set { this.RaiseAndSetIfChanged(ref hoverTabBackgroundBrush, value); }
-        }
     }
 }

--- a/AvalonStudio/AvalonStudio/Controls/DocumentTabControlViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/DocumentTabControlViewModel.cs
@@ -69,11 +69,11 @@ namespace AvalonStudio.Controls
                 if (value is IEditor editor)
                 {
                     // Dispatcher invoke is hack to make sure the Editor propery has been generated.
-                    Dispatcher.UIThread.InvokeAsync(() =>
+                    
                     {                        
                         editor.Focus();
                         editor.TriggerCodeAnalysis();
-                    });
+                    }//);
                 }
 
                 if (value == TemporaryDocument)

--- a/AvalonStudio/AvalonStudio/Controls/DocumentTabControlViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/DocumentTabControlViewModel.cs
@@ -1,5 +1,6 @@
 using Avalonia.Media;
 using Avalonia.Threading;
+using AvalonStudio.Documents;
 using AvalonStudio.MVVM;
 using ReactiveUI;
 using System;
@@ -65,14 +66,13 @@ namespace AvalonStudio.Controls
 
                 this.RaisePropertyChanged(nameof(SelectedDocument));
 
-                if (value is EditorViewModel)
+                if (value is IEditor editor)
                 {
                     // Dispatcher invoke is hack to make sure the Editor propery has been generated.
                     Dispatcher.UIThread.InvokeAsync(() =>
-                    {
-                        var vm = value as EditorViewModel;
-                      //  vm.Focus();
-                       // vm.TriggerCodeAnalysis();
+                    {                        
+                        editor.Focus();
+                        editor.TriggerCodeAnalysis();
                     });
                 }
 

--- a/AvalonStudio/AvalonStudio/Controls/DocumentTabControlViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/DocumentTabControlViewModel.cs
@@ -4,6 +4,7 @@ using AvalonStudio.Documents;
 using AvalonStudio.MVVM;
 using ReactiveUI;
 using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Threading.Tasks;
@@ -12,24 +13,22 @@ namespace AvalonStudio.Controls
 {
     public class DocumentTabControlViewModel : ViewModel
     {
-        private ObservableCollection<IDocumentTabViewModel> documents;        
+        private ObservableCollection<IDocumentTabViewModel> documents;
+        private List<IDocumentTabViewModel> cachedDocuments;
 
         private IDocumentTabViewModel selectedDocument;
 
         public DocumentTabControlViewModel()
         {
-            Documents = new ObservableCollection<IDocumentTabViewModel>();
-            Documents.CollectionChanged += (sender, e) =>
-            {
-                if (e.Action == NotifyCollectionChangedAction.Remove)
-                {
-                    Dispatcher.UIThread.InvokeAsync(async () =>
-                    {
-                        await Task.Delay(25);
-                        GC.Collect();
-                    });
-                }
-            };
+            CachedDocuments = new List<IDocumentTabViewModel>();
+
+            Documents = new ObservableCollection<IDocumentTabViewModel>();            
+        }
+
+        public List<IDocumentTabViewModel> CachedDocuments
+        {
+            get { return cachedDocuments; }
+            set { this.RaiseAndSetIfChanged(ref cachedDocuments, value); }
         }
 
         public ObservableCollection<IDocumentTabViewModel> Documents

--- a/AvalonStudio/AvalonStudio/Controls/Editor/EditorViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/Editor/EditorViewModel.cs
@@ -38,7 +38,7 @@ namespace AvalonStudio.Controls
 
         public void TriggerCodeAnalysis()
         {
-            _editor.TriggerCodeAnalysis();
+            _editor?.TriggerCodeAnalysis();
         }
 
         public void Comment()

--- a/AvalonStudio/AvalonStudio/Controls/Editor/EditorViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/Editor/EditorViewModel.cs
@@ -31,6 +31,16 @@ namespace AvalonStudio.Controls
             _editor?.SetDebugHighlight(line, startColumn, endColumn);
         }
 
+        public void Focus()
+        {
+            _editor?.Focus();
+        }
+
+        public void TriggerCodeAnalysis()
+        {
+            _editor.TriggerCodeAnalysis();
+        }
+
         public void Comment()
         {
             _editor?.Comment();

--- a/AvalonStudio/AvalonStudio/Controls/Editor/EditorViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/Editor/EditorViewModel.cs
@@ -90,11 +90,8 @@ namespace AvalonStudio.Controls
             disposables = new CompositeDisposable();
 
             disposables.Add(CloseCommand.Subscribe(_ =>
-            {
-                _editor?.Close();
-
-                IoC.Get<IShell>().InvalidateErrors();
-                disposables.Dispose();
+            {                
+                IoC.Get<IShell>().InvalidateErrors();                
             }));
 
             AddWatchCommand = ReactiveCommand.Create();
@@ -105,6 +102,12 @@ namespace AvalonStudio.Controls
 
         ~EditorViewModel()
         {
+        }
+
+        public override void OnClose()
+        {
+            _editor?.Close();
+            disposables.Dispose();
         }
 
         public void AttachEditor(IEditor editor)

--- a/AvalonStudio/AvalonStudio/Controls/EditorView.xaml.cs
+++ b/AvalonStudio/AvalonStudio/Controls/EditorView.xaml.cs
@@ -21,6 +21,8 @@ namespace AvalonStudio.Controls
         
         private Standard.CodeEditor.CodeEditor _editor;
 
+        private IShell shell;
+
         public ISourceFile ProjectFile => throw new NotImplementedException();
 
         public int CaretOffset => _editor.CaretOffset;
@@ -45,13 +47,17 @@ namespace AvalonStudio.Controls
 
             _editor.RequestTooltipContent += _editor_RequestTooltipContent;
 
+            shell = IoC.Get<IShell>();
+
             _editor.GetObservable(AvalonStudio.Controls.Standard.CodeEditor.CodeEditor.IsDirtyProperty).Subscribe(dirty =>
             {
                 if (dirty && DataContext is EditorViewModel editorVm)
                 {
                     editorVm.Dock = Dock.Left;
+
+                    // Selecting the document event though it already is, causes it to be removed from the temporary document cache.
                     editorVm.IsTemporary = false;
-                    IoC.Get<IShell>().SelectedDocument = editorVm;
+                    shell.SelectedDocument = editorVm;
                 }
             });
         }

--- a/AvalonStudio/AvalonStudio/Controls/EditorView.xaml.cs
+++ b/AvalonStudio/AvalonStudio/Controls/EditorView.xaml.cs
@@ -9,6 +9,9 @@ using AvalonStudio.Documents;
 using AvalonStudio.Projects;
 using System.Threading.Tasks;
 using AvalonStudio.Languages;
+using AvalonStudio.Shell;
+using AvalonStudio.Extensibility;
+using Avalonia.Input;
 
 namespace AvalonStudio.Controls
 {
@@ -41,6 +44,16 @@ namespace AvalonStudio.Controls
             _editor = this.FindControl<Standard.CodeEditor.CodeEditor>("editor");
 
             _editor.RequestTooltipContent += _editor_RequestTooltipContent;
+
+            _editor.GetObservable(AvalonStudio.Controls.Standard.CodeEditor.CodeEditor.IsDirtyProperty).Subscribe(dirty =>
+            {
+                if (dirty && DataContext is EditorViewModel editorVm)
+                {
+                    editorVm.Dock = Dock.Left;
+                    editorVm.IsTemporary = false;
+                    IoC.Get<IShell>().SelectedDocument = editorVm;
+                }
+            });
         }
 
         private void _editor_RequestTooltipContent(object sender, Standard.TooltipDataRequestEventArgs e)
@@ -53,22 +66,22 @@ namespace AvalonStudio.Controls
             }
         }
 
-        private void Editor_EditorScrolled(object sender, EventArgs e)
-        {
-           // editorViewModel.Intellisense.IsVisible = false;
-        }
-
-        private void Editor_CaretChangedByPointerClick(object sender, EventArgs e)
-        {
-            //editorViewModel.Intellisense.IsVisible = false;
-        }
-
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
            // editor.EditorScrolled -= Editor_EditorScrolled;
             //editor.CaretChangedByPointerClick -= Editor_CaretChangedByPointerClick;
 
             disposables.Dispose();
+        }
+
+        protected override void OnGotFocus(GotFocusEventArgs e)
+        {
+            _editor.Focus();
+        }
+
+        public void TriggerCodeAnalysis()
+        {
+            _editor.TriggerCodeAnalysis();
         }
 
         private void InitializeComponent()

--- a/AvalonStudio/AvalonStudio/Controls/EditorView.xaml.cs
+++ b/AvalonStudio/AvalonStudio/Controls/EditorView.xaml.cs
@@ -18,7 +18,7 @@ namespace AvalonStudio.Controls
     public class EditorView : UserControl, IEditor
     {
         private readonly CompositeDisposable disposables;
-        
+
         private Standard.CodeEditor.CodeEditor _editor;
 
         private IShell shell;
@@ -64,7 +64,7 @@ namespace AvalonStudio.Controls
 
         private void _editor_RequestTooltipContent(object sender, Standard.TooltipDataRequestEventArgs e)
         {
-            if(DataContext != null)
+            if (DataContext != null)
             {
                 var editorVm = DataContext as EditorViewModel;
 
@@ -74,7 +74,7 @@ namespace AvalonStudio.Controls
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
-           // editor.EditorScrolled -= Editor_EditorScrolled;
+            // editor.EditorScrolled -= Editor_EditorScrolled;
             //editor.CaretChangedByPointerClick -= Editor_CaretChangedByPointerClick;
 
             disposables.Dispose();

--- a/AvalonStudio/AvalonStudio/Controls/EditorView.xaml.cs
+++ b/AvalonStudio/AvalonStudio/Controls/EditorView.xaml.cs
@@ -57,7 +57,7 @@ namespace AvalonStudio.Controls
 
                     // Selecting the document event though it already is, causes it to be removed from the temporary document cache.
                     editorVm.IsTemporary = false;
-                    shell.SelectedDocument = editorVm;
+                    shell.SelectedDocument = editorVm;                    
                 }
             });
         }

--- a/AvalonStudio/AvalonStudio/MainWindow.paml
+++ b/AvalonStudio/AvalonStudio/MainWindow.paml
@@ -1,5 +1,6 @@
 ﻿<Controls:MetroWindow xmlns="https://github.com/avaloniaui"
                       xmlns:Controls="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio"
+                      xmlns:cont="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio.Extensibility"
                       xmlns:menu="clr-namespace:AvalonStudio.Extensibility.MainMenu.ViewModels;assembly=AvalonStudio.Extensibility"
                       xmlns:dock="clr-namespace:Mabiavalon.DockNC;assembly=Mabiavalon.DockNC"
                       xmlns:docking="clr-namespace:Mabiavalon.DockNC.Docking;assembly=Mabiavalon.DockNC"
@@ -75,7 +76,7 @@
                             <Controls:TabControlView DataContext="{Binding MiddleTopTabs}" IsVisible="{Binding IsVisible}" />
                           </docking:Branch.FirstItem>
                           <docking:Branch.SecondItem>
-                            <Controls:DocumentTabControl DataContext="{Binding DocumentTabs}"  />
+                            <cont:DocumentTabControl DataContext="{Binding DocumentTabs}"  />
                           </docking:Branch.SecondItem>
                         </docking:Branch>
                       </docking:Branch.FirstItem>

--- a/AvalonStudio/AvalonStudio/MainWindow.paml
+++ b/AvalonStudio/AvalonStudio/MainWindow.paml
@@ -1,6 +1,5 @@
 ﻿<Controls:MetroWindow xmlns="https://github.com/avaloniaui"
                       xmlns:Controls="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio"
-                      xmlns:cont="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio.Extensibility"
                       xmlns:menu="clr-namespace:AvalonStudio.Extensibility.MainMenu.ViewModels;assembly=AvalonStudio.Extensibility"
                       xmlns:dock="clr-namespace:Mabiavalon.DockNC;assembly=Mabiavalon.DockNC"
                       xmlns:docking="clr-namespace:Mabiavalon.DockNC.Docking;assembly=Mabiavalon.DockNC"
@@ -76,7 +75,7 @@
                             <Controls:TabControlView DataContext="{Binding MiddleTopTabs}" IsVisible="{Binding IsVisible}" />
                           </docking:Branch.FirstItem>
                           <docking:Branch.SecondItem>
-                            <cont:DocumentTabControl DataContext="{Binding DocumentTabs}"  />
+                            <Controls:DocumentTabControl DataContext="{Binding DocumentTabs}"  />
                           </docking:Branch.SecondItem>
                         </docking:Branch>
                       </docking:Branch.FirstItem>

--- a/AvalonStudio/AvalonStudio/ShellViewModel.cs
+++ b/AvalonStudio/AvalonStudio/ShellViewModel.cs
@@ -334,6 +334,7 @@ namespace AvalonStudio
         {
             DocumentTabs.Documents.Add(document);
             DocumentTabs.SelectedDocument = document;
+            DocumentTabs.InvalidateSeperatorVisibility();
         }
 
         public void RemoveDocument(IDocumentTabViewModel document)
@@ -420,6 +421,8 @@ namespace AvalonStudio
             }
 
             DocumentTabs.CachedDocuments.Add(document);
+
+            DocumentTabs.InvalidateSeperatorVisibility();
         }
 
         public async Task<IEditor> OpenDocument(ISourceFile file, int line, int startColumn = -1, int endColumn = -1, bool debugHighlight = false, bool selectLine = false)
@@ -476,9 +479,7 @@ namespace AvalonStudio
 
                 newEditor.OpenFile(file);
 
-                DocumentTabs.TemporaryDocument = newEditor;
-
-                DocumentTabs.SelectedDocument = newEditor;
+                AddDocument(newEditor);
             }
             else
             {

--- a/AvalonStudio/AvalonStudio/ShellViewModel.cs
+++ b/AvalonStudio/AvalonStudio/ShellViewModel.cs
@@ -6,7 +6,6 @@ using AvalonStudio.Debugging;
 using AvalonStudio.Documents;
 using AvalonStudio.Extensibility;
 using AvalonStudio.Extensibility.Commands;
-using AvalonStudio.Extensibility.Dialogs;
 using AvalonStudio.Extensibility.MainMenu;
 using AvalonStudio.Extensibility.MainToolBar;
 using AvalonStudio.Extensibility.Menus;
@@ -580,7 +579,7 @@ namespace AvalonStudio
             {
                 if (DocumentTabs != null)
                 {
-                    if (value == null || DocumentTabs.TemporaryDocument == value && !value.IsTemporary)
+                    if (value == null || (DocumentTabs.TemporaryDocument == value && !value.IsTemporary))
                     {
                         DocumentTabs.TemporaryDocument = null;
                     }

--- a/AvalonStudio/AvalonStudio/ShellViewModel.cs
+++ b/AvalonStudio/AvalonStudio/ShellViewModel.cs
@@ -344,11 +344,11 @@ namespace AvalonStudio
             {
                 if (DocumentTabs.SelectedDocument != DocumentTabs.Documents.Last())
                 {
-                    newSelectedTab = DocumentTabs.Documents.SkipWhile(d => d == document).FirstOrDefault();
+                    newSelectedTab = DocumentTabs.Documents.SkipWhile(d => d == document || !d.IsVisible).FirstOrDefault();
                 }
                 else
                 {
-                    newSelectedTab = DocumentTabs.Documents.Reverse().Skip(1).FirstOrDefault();
+                    newSelectedTab = DocumentTabs.Documents.Reverse().SkipWhile(d=>!d.IsVisible || d != DocumentTabs.Documents.Last()).FirstOrDefault();
                 }
             }
 
@@ -425,6 +425,8 @@ namespace AvalonStudio
                 {
                     newEditor.IsVisible = true;
                     DocumentTabs.CachedDocuments.Remove(currentTab);
+                    newEditor.IsTemporary = true;
+                    newEditor.Dock = Avalonia.Controls.Dock.Right;
                 }
                 else
                 {

--- a/AvalonStudio/AvalonStudio/ShellViewModel.cs
+++ b/AvalonStudio/AvalonStudio/ShellViewModel.cs
@@ -580,7 +580,12 @@ namespace AvalonStudio
             {
                 if (DocumentTabs != null)
                 {
-                    DocumentTabs.SelectedDocument = value;
+                    if (DocumentTabs.TemporaryDocument == value && !value.IsTemporary)
+                    {
+                        DocumentTabs.TemporaryDocument = null;
+                    }
+
+                    DocumentTabs.SelectedDocument = value;                    
                 }
             }
         }

--- a/AvalonStudio/AvalonStudio/ShellViewModel.cs
+++ b/AvalonStudio/AvalonStudio/ShellViewModel.cs
@@ -6,6 +6,7 @@ using AvalonStudio.Debugging;
 using AvalonStudio.Documents;
 using AvalonStudio.Extensibility;
 using AvalonStudio.Extensibility.Commands;
+using AvalonStudio.Extensibility.Dialogs;
 using AvalonStudio.Extensibility.MainMenu;
 using AvalonStudio.Extensibility.MainToolBar;
 using AvalonStudio.Extensibility.Menus;

--- a/AvalonStudio/AvalonStudio/ShellViewModel.cs
+++ b/AvalonStudio/AvalonStudio/ShellViewModel.cs
@@ -400,7 +400,7 @@ namespace AvalonStudio
 
                     DocumentTabs.SelectedDocument = newEditor;
 
-                   await Dispatcher.UIThread.InvokeTaskAsync(() => { newEditor.OpenFile(file); });
+                    await Dispatcher.UIThread.InvokeTaskAsync(() => { newEditor.OpenFile(file); });
 
                     selectedDocumentTCS.SetResult(DocumentTabs.SelectedDocument);
                 });
@@ -423,7 +423,7 @@ namespace AvalonStudio
 
                 if (selectLine || debugHighlight)
                 {
-                   // Dispatcher.UIThread.InvokeAsync(() => (DocumentTabs.SelectedDocument as EditorViewModel).ScrollToLine(line));
+                    // Dispatcher.UIThread.InvokeAsync(() => (DocumentTabs.SelectedDocument as EditorViewModel).ScrollToLine(line));
                     (DocumentTabs.SelectedDocument as IEditor).GotoPosition(line, startColumn != -1 ? 1 : startColumn);
                 }
             }
@@ -585,7 +585,7 @@ namespace AvalonStudio
                         DocumentTabs.TemporaryDocument = null;
                     }
 
-                    DocumentTabs.SelectedDocument = value;                    
+                    DocumentTabs.SelectedDocument = value;
                 }
             }
         }
@@ -636,7 +636,7 @@ namespace AvalonStudio
         {
             Environment.Exit(1);
         }
-        
+
         public void InvalidateErrors()
         {
             var allErrors = new List<ErrorViewModel>();
@@ -697,7 +697,7 @@ namespace AvalonStudio
         {
             foreach (var document in DocumentTabs.Documents.OfType<EditorViewModel>())
             {
-               // document.Model.ShutdownBackgroundWorkers();
+                // document.Model.ShutdownBackgroundWorkers();
             }
         }
 

--- a/AvalonStudio/AvalonStudio/ShellViewModel.cs
+++ b/AvalonStudio/AvalonStudio/ShellViewModel.cs
@@ -293,7 +293,7 @@ namespace AvalonStudio
 
         public IEnumerable<KeyBinding> KeyBindings => _keyBindings;
 
-        public DocumentTabControlViewModel DocumentTabs { get; }        
+        public DocumentTabControlViewModel DocumentTabs { get; }
 
         public TabControlViewModel LeftTabs { get; }
 
@@ -342,19 +342,60 @@ namespace AvalonStudio
 
             if (DocumentTabs.SelectedDocument == document)
             {
-                if (DocumentTabs.SelectedDocument != DocumentTabs.Documents.Last())
+                var index = DocumentTabs.Documents.IndexOf(document);
+                var current = index;
+
+                bool foundTab = false;
+
+                while(!foundTab)
                 {
-                    newSelectedTab = DocumentTabs.Documents.SkipWhile(d => d == document || !d.IsVisible).FirstOrDefault();
+                    index++;
+
+                    if(index < DocumentTabs.Documents.Count)
+                    {
+                        if (DocumentTabs.Documents[index].IsVisible)
+                        {
+                            foundTab = true;
+                            newSelectedTab = DocumentTabs.Documents[index];
+                            break;
+                        }
+                    }            
+                    else
+                    {
+                        break;
+                    }
                 }
-                else
+
+                index = current;
+
+                while (!foundTab)
                 {
-                    newSelectedTab = DocumentTabs.Documents.Reverse().SkipWhile(d=>!d.IsVisible || d != DocumentTabs.Documents.Last()).FirstOrDefault();
+                    index--;
+
+                    if (index >= 0)
+                    {
+                        if (DocumentTabs.Documents[index].IsVisible)
+                        {
+                            foundTab = true;
+                            newSelectedTab = DocumentTabs.Documents[index];
+                            break;
+                        }
+                    }
+                    else
+                    {
+                        break;
+                    }
                 }
             }
 
             DocumentTabs.SelectedDocument = newSelectedTab;
 
             document.IsVisible = false;
+
+            if (document is EditorViewModel doc)
+            {
+                doc.Save();
+            }
 
             if (DocumentTabs.TemporaryDocument == document)
             {
@@ -378,12 +419,12 @@ namespace AvalonStudio
                 });
             }
 
-            DocumentTabs.CachedDocuments.Add(document);            
+            DocumentTabs.CachedDocuments.Add(document);
         }
 
         public async Task<IEditor> OpenDocument(ISourceFile file, int line, int startColumn = -1, int endColumn = -1, bool debugHighlight = false, bool selectLine = false)
         {
-            bool restoreFromCache = false;            
+            bool restoreFromCache = false;
 
             var currentTab = DocumentTabs.CachedDocuments.OfType<EditorViewModel>().FirstOrDefault(t => t.ProjectFile?.FilePath == file.FilePath);
 
@@ -437,12 +478,12 @@ namespace AvalonStudio
 
                 DocumentTabs.TemporaryDocument = newEditor;
 
-                DocumentTabs.SelectedDocument = newEditor;                
+                DocumentTabs.SelectedDocument = newEditor;
             }
             else
             {
                 DocumentTabs.SelectedDocument = currentTab;
-            }            
+            }
 
             if (DocumentTabs.SelectedDocument is IEditor)
             {

--- a/AvalonStudio/AvalonStudio/ShellViewModel.cs
+++ b/AvalonStudio/AvalonStudio/ShellViewModel.cs
@@ -580,7 +580,7 @@ namespace AvalonStudio
             {
                 if (DocumentTabs != null)
                 {
-                    if (DocumentTabs.TemporaryDocument == value && !value.IsTemporary)
+                    if (value == null || DocumentTabs.TemporaryDocument == value && !value.IsTemporary)
                     {
                         DocumentTabs.TemporaryDocument = null;
                     }

--- a/AvalonStudio/AvalonStudio/ShellViewModel.cs
+++ b/AvalonStudio/AvalonStudio/ShellViewModel.cs
@@ -19,7 +19,6 @@ using AvalonStudio.Platforms;
 using AvalonStudio.Projects;
 using AvalonStudio.Shell;
 using AvalonStudio.TestFrameworks;
-using AvalonStudio.TextEditor;
 using AvalonStudio.Toolchains;
 using AvalonStudio.Utils;
 using ReactiveUI;
@@ -334,6 +333,7 @@ namespace AvalonStudio
         {
             DocumentTabs.Documents.Add(document);
             DocumentTabs.SelectedDocument = document;
+
             DocumentTabs.InvalidateSeperatorVisibility();
         }
 
@@ -468,18 +468,18 @@ namespace AvalonStudio
                 if (restoreFromCache)
                 {
                     newEditor.IsVisible = true;
-                    DocumentTabs.CachedDocuments.Remove(currentTab);
-                    newEditor.IsTemporary = true;
+                    DocumentTabs.CachedDocuments.Remove(currentTab);                    
                     newEditor.Dock = Avalonia.Controls.Dock.Right;
+                    DocumentTabs.SelectedDocument = newEditor;
                 }
                 else
                 {
-                    DocumentTabs.Documents.Add(newEditor);
+                    newEditor.OpenFile(file);
+                    AddDocument(newEditor);
                 }
 
-                newEditor.OpenFile(file);
-
-                AddDocument(newEditor);
+                newEditor.IsTemporary = true;
+                DocumentTabs.TemporaryDocument = newEditor;
             }
             else
             {

--- a/AvalonStudio/AvalonStudio/Themes/Accents/DarkAccent.xaml
+++ b/AvalonStudio/AvalonStudio/Themes/Accents/DarkAccent.xaml
@@ -5,9 +5,14 @@
   <Style.Resources>
     <!--NOTE: This is a partial accent.-->
 
-    <!--Brushes-->
+    <!--Brushes-->       
+    <SolidColorBrush x:Key="ApplicationAccentBrush">#007ACC</SolidColorBrush>
+    <SolidColorBrush x:Key="ApplicationAccentBrushLight">#1C97EA</SolidColorBrush>
+    <SolidColorBrush x:Key="ApplicationAccentForegroundBrush">#F0F0F0</SolidColorBrush>
+    <SolidColorBrush x:Key="ApplicationBackgroundBrush">#EEEEF2</SolidColorBrush>
+    <SolidColorBrush x:Key="ApplicationBorderBrush">#CDCFDC</SolidColorBrush>
 
-    <!--The main accent color-->
+        <!--The main accent color-->
     <SolidColorBrush x:Key="AccentBaseColorBrush">#FFE51400</SolidColorBrush>
 
     <!--A neutral color (black or white) that should be used against a background of the base accent color-->


### PR DESCRIPTION
- [x] Migrate from being user control to tab control
- [x] dont trigger code analysis if the document isnt dirty since the last analysis (AnalysisIsDirty)
- [x] purple tab if its temporary.
- [x] then add cache of last 5 documents, (open but no longer visible, i.e. not in documents list)
- [x] Get rid of blue stripe if there a no elements in the tabs.
- [x] Get cache to expire after a few minutes? (wont do this)
- [x] Improve performance of opening a new document.