### PR TITLE
use TSBridge 1.0.2 with fixes

### DIFF
--- a/AvalonStudio/AvalonStudio.LanguageSupport.TypeScript/AvalonStudio.LanguageSupport.TypeScript.csproj
+++ b/AvalonStudio/AvalonStudio.LanguageSupport.TypeScript/AvalonStudio.LanguageSupport.TypeScript.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TSBridge" Version="1.0.0" />
+    <PackageReference Include="TSBridge" Version="1.0.2" />
   </ItemGroup>
       
   <ItemGroup>


### PR DESCRIPTION
TSBridge 1.0.2 includes IridiumJS 2.10.3.4, which has fixes for the JS engine powering TSBridge.