### PR TITLE
[PACKAGE] DEB - Fix icon location in packaging script.

### DIFF
--- a/packages/package-debian.sh
+++ b/packages/package-debian.sh
@@ -17,6 +17,6 @@ sed -i -e "s/{VERSION}/$BUILD_VERSION/g" $PACK_DIR/avalon-studio_$BUILD_VERSION/
 chmod +x $TARG_DIR/native/unix/clang-format
 
 mkdir -p $PACK_DIR/avalon-studio_$BUILD_VERSION/usr/share/pixmaps/
-cp $BUILD_DIR/icon.png $PACK_DIR/avalon-studio_$BUILD_VERSION/usr/share/pixmaps/avalon-studio.png
+cp $BUILD_DIR/Assets/icon.png $PACK_DIR/avalon-studio_$BUILD_VERSION/usr/share/pixmaps/avalon-studio.png
 dpkg-deb --build $PACK_DIR/avalon-studio_$BUILD_VERSION
 


### PR DESCRIPTION
LGTM - fix copying of icon from Assets folder after icon.png was moved.