### PR TITLE
Enable syntax highlighting for XAML

### DIFF
--- a/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/AvaloniaEditTextDocumentAdaptor.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/AvaloniaEditTextDocumentAdaptor.cs
@@ -136,6 +136,8 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
         private AvaloniaEdit.Document.TextDocument _document;
         private DocumentLinesCollection _lines;
 
+        internal AvaloniaEdit.Document.TextDocument Document => _document;
+
         public DocumentAdaptor(AvaloniaEdit.Document.TextDocument document)
         {
             _document = document;
@@ -153,14 +155,21 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
 
         public int LineCount => _document.LineCount;
 
+        public int TextLength => _document.TextLength;
+
+        public void Insert(int offset, string text)
+        {
+            Replace(offset, 0, text);
+        }
+
         public void Replace(int offset, int length, string text)
         {
             _document.Replace(offset, length, text);
         }
 
-        public void Insert(int offset, string text)
+        public char GetCharAt(int offset)
         {
-            Replace(offset, 0, text);
+            return _document.GetCharAt(offset);
         }
 
         public string GetText(int offset, int length)

--- a/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/AvaloniaEditTextDocumentAdaptor.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/AvaloniaEditTextDocumentAdaptor.cs
@@ -1,0 +1,46 @@
+﻿using Avalonia.Input;
+using AvaloniaEdit.Document;
+using AvalonStudio.Extensibility.Documents;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AvalonStudio.Controls.Standard.CodeEditor
+{
+    public class CodeEditorDocumentAdaptor : ITextDocument
+    {
+        private CodeEditor _codeEditor;
+
+        public CodeEditorDocumentAdaptor(CodeEditor editor)
+        {
+            _codeEditor = editor;
+
+            _codeEditor.TextArea.TextEntering += TextEntering;
+            _codeEditor.TextArea.TextEntered += TextEntered;
+        }
+
+        ~CodeEditorDocumentAdaptor()
+        {
+            _codeEditor.TextArea.TextEntering -= TextEntering;
+            _codeEditor.TextArea.TextEntered -= TextEntered;
+        }
+
+        /// <summary>
+        /// Occurs when the TextArea receives text input.
+        /// but occurs immediately before the TextArea handles the TextInput event.
+        /// </summary>
+        public event EventHandler<TextInputEventArgs> TextEntering;
+
+        /// <summary>
+        /// Occurs when the TextArea receives text input.
+        /// but occurs immediately after the TextArea handles the TextInput event.
+        /// </summary>
+        public event EventHandler<TextInputEventArgs> TextEntered;
+
+
+        public void Save()
+        {
+            _codeEditor.Save();
+        }
+    }
+}

--- a/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/AvaloniaEditTextDocumentAdaptor.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/AvaloniaEditTextDocumentAdaptor.cs
@@ -14,7 +14,12 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
 
             _codeEditor.TextArea.TextEntering += TextEntering;
             _codeEditor.TextArea.TextEntered += TextEntered;
-        }        
+        }
+
+        ~CodeEditorDocumentAdaptor()
+        {
+            System.Console.WriteLine("Adaptor Disposed");
+        }
 
         /// <summary>
         /// Occurs when the TextArea receives text input.

--- a/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/AvaloniaEditTextDocumentAdaptor.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/AvaloniaEditTextDocumentAdaptor.cs
@@ -1,9 +1,6 @@
 ﻿using Avalonia.Input;
-using AvaloniaEdit.Document;
 using AvalonStudio.Extensibility.Documents;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace AvalonStudio.Controls.Standard.CodeEditor
 {
@@ -17,13 +14,7 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
 
             _codeEditor.TextArea.TextEntering += TextEntering;
             _codeEditor.TextArea.TextEntered += TextEntered;
-        }
-
-        ~CodeEditorDocumentAdaptor()
-        {
-            _codeEditor.TextArea.TextEntering -= TextEntering;
-            _codeEditor.TextArea.TextEntered -= TextEntered;
-        }
+        }        
 
         /// <summary>
         /// Occurs when the TextArea receives text input.
@@ -37,10 +28,25 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
         /// </summary>
         public event EventHandler<TextInputEventArgs> TextEntered;
 
+        public string Text => _codeEditor.Text;
+
+        public int Caret { get => _codeEditor.CaretOffset; set => _codeEditor.CaretOffset = value; }
 
         public void Save()
         {
             _codeEditor.Save();
+        }
+
+        public void Replace(int offset, int length, string text)
+        {
+            _codeEditor.Document.Replace(offset, length, text);
+        }
+
+        public void Dispose()
+        {
+            _codeEditor.TextArea.TextEntering -= TextEntering;
+            _codeEditor.TextArea.TextEntered -= TextEntered;
+            _codeEditor = null;
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/AvaloniaEditTextDocumentAdaptor.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/AvaloniaEditTextDocumentAdaptor.cs
@@ -1,25 +1,115 @@
 ﻿using Avalonia.Input;
 using AvalonStudio.Extensibility.Documents;
 using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
 
 namespace AvalonStudio.Controls.Standard.CodeEditor
 {
-    public class CodeEditorDocumentAdaptor : ITextDocument
+    public class DocumentLinesCollection : IIndexableList<IDocumentLine>
+    {
+        private AvaloniaEdit.Document.TextDocument _document;
+
+        public DocumentLinesCollection(AvaloniaEdit.Document.TextDocument document)
+        {
+            _document = document;
+        }
+
+        public IDocumentLine this[int index] => new DocumentLine(_document.Lines[index]);
+
+        public int Count => _document.Lines.Count;
+
+        public IEnumerator<IDocumentLine> GetEnumerator()
+        {
+            return _document.Lines.Select(l => new DocumentLine(l)).GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _document.Lines.Select(l => new DocumentLine(l)).GetEnumerator();
+        }
+    }
+
+    public class DocumentLine : IDocumentLine
+    {
+        AvaloniaEdit.Document.DocumentLine _line;
+
+        public DocumentLine(AvaloniaEdit.Document.DocumentLine line)
+        {
+            _line = line;
+        }
+
+        public int TotalLength => _line.TotalLength;
+
+        public int DelimiterLength => _line.DelimiterLength;
+
+        public int LineNumber => _line.LineNumber;
+
+        public IDocumentLine PreviousLine
+        {
+            get
+            {
+                if (_line.PreviousLine != null)
+                {
+                    return new DocumentLine(_line.PreviousLine);
+                }
+
+                return null;
+            }
+        }
+
+        public IDocumentLine NextLine
+        {
+            get
+            {
+                if (_line.NextLine != null)
+                {
+                    return new DocumentLine(_line.NextLine);
+                }
+
+                return null;
+            }
+        }
+
+        public int Offset => _line.Offset;
+
+        public int Length => _line.Length;
+
+        public int EndOffset => _line.EndOffset;
+    }
+
+    public class EditorAdaptor : IEditor
     {
         private CodeEditor _codeEditor;
+        private DocumentAdaptor _document;
 
-        public CodeEditorDocumentAdaptor(CodeEditor editor)
+        public EditorAdaptor(CodeEditor editor)
         {
             _codeEditor = editor;
+            _document = new DocumentAdaptor(editor.Document);
 
             _codeEditor.TextArea.TextEntering += TextEntering;
             _codeEditor.TextArea.TextEntered += TextEntered;
         }
 
-        ~CodeEditorDocumentAdaptor()
+        public ITextDocument Document => _document;
+
+        public void Save()
         {
-            System.Console.WriteLine("Adaptor Disposed");
+            _codeEditor.Save();
         }
+
+        public void IndentLine(int line)
+        {
+            _codeEditor.LanguageService?.IndentationStrategy.IndentLine(_codeEditor.Document, _codeEditor.Document.Lines[line]);
+        }
+
+        public int Offset { get => _codeEditor.CaretOffset; set => _codeEditor.CaretOffset = value; }
+
+        public int Line { get => _codeEditor.TextArea.Caret.Line; set => _codeEditor.TextArea.Caret.Line = value; }
+
+        public int Column { get => _codeEditor.TextArea.Caret.Column; set => _codeEditor.TextArea.Caret.Column = value; }
 
         /// <summary>
         /// Occurs when the TextArea receives text input.
@@ -33,25 +123,54 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
         /// </summary>
         public event EventHandler<TextInputEventArgs> TextEntered;
 
-        public string Text => _codeEditor.Text;
-
-        public int Caret { get => _codeEditor.CaretOffset; set => _codeEditor.CaretOffset = value; }
-
-        public void Save()
-        {
-            _codeEditor.Save();
-        }
-
-        public void Replace(int offset, int length, string text)
-        {
-            _codeEditor.Document.Replace(offset, length, text);
-        }
-
         public void Dispose()
         {
             _codeEditor.TextArea.TextEntering -= TextEntering;
             _codeEditor.TextArea.TextEntered -= TextEntered;
             _codeEditor = null;
+        }
+    }
+
+    public class DocumentAdaptor : ITextDocument
+    {
+        private AvaloniaEdit.Document.TextDocument _document;
+        private DocumentLinesCollection _lines;
+
+        public DocumentAdaptor(AvaloniaEdit.Document.TextDocument document)
+        {
+            _document = document;
+            _lines = new DocumentLinesCollection(document);
+        }
+
+        ~DocumentAdaptor()
+        {
+            System.Console.WriteLine("Adaptor Disposed");
+        }
+
+        public string Text => _document.Text;
+
+        public IIndexableList<IDocumentLine> Lines => _lines;
+
+        public int LineCount => _document.LineCount;
+
+        public void Replace(int offset, int length, string text)
+        {
+            _document.Replace(offset, length, text);
+        }
+
+        public void Insert(int offset, string text)
+        {
+            Replace(offset, 0, text);
+        }
+
+        public string GetText(int offset, int length)
+        {
+            return _document.GetText(offset, length);
+        }
+
+        public IDisposable RunUpdate()
+        {
+            return _document.RunUpdate();
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/BreakPointMargin.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/BreakPointMargin.cs
@@ -10,10 +10,10 @@ using System.Linq;
 
 namespace AvalonStudio.Controls.Standard.CodeEditor
 {
-    public class BreakPointMargin : AbstractMargin
+    public class BreakPointMargin : AbstractMargin, IDisposable
     {
-        private readonly BreakpointStore _manager;
-        private readonly CodeEditor _editor;
+        private BreakpointStore _manager;
+        private CodeEditor _editor;
 
         private int previewLine;
         private bool previewPointVisible;
@@ -141,6 +141,12 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
         {
             InvalidateVisual();
             e.Handled = true;
+        }
+
+        public void Dispose()
+        {
+            _manager = null;
+            _editor = null;
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/CodeEditor.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/CodeEditor.cs
@@ -308,7 +308,7 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
                                 FileName = file.Item2.Location
                             };
 
-                            DocumentAccessor = new CodeEditorDocumentAdaptor(this);
+                            DocumentAccessor = new EditorAdaptor(this);
                         }
                     }
 
@@ -1028,10 +1028,10 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
             set => SetValue(SourceTextProperty, value);
         }
 
-        public static readonly AvaloniaProperty<ITextDocument> DocumentAccessorProperty =
-            AvaloniaProperty.Register<CodeEditor, ITextDocument>(nameof(DocumentAccessor), defaultBindingMode: BindingMode.TwoWay);
+        public static readonly AvaloniaProperty<IEditor> DocumentAccessorProperty =
+            AvaloniaProperty.Register<CodeEditor, IEditor>(nameof(DocumentAccessor), defaultBindingMode: BindingMode.TwoWay);
 
-        public ITextDocument DocumentAccessor
+        public IEditor DocumentAccessor
         {
             get => GetValue(DocumentAccessorProperty);
             set => SetValue(DocumentAccessorProperty, value);

--- a/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/CodeEditor.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/CodeEditor.cs
@@ -10,6 +10,7 @@ using AvaloniaEdit;
 using AvaloniaEdit.Document;
 using AvaloniaEdit.Editing;
 using AvaloniaEdit.Highlighting;
+using AvaloniaEdit.Indentation;
 using AvaloniaEdit.Rendering;
 using AvaloniaEdit.Snippets;
 using AvalonStudio.CodeEditor;
@@ -719,6 +720,11 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
                 _disposables.Add(_intellisenseManager);
 
                 TextArea.IndentationStrategy = LanguageService.IndentationStrategy;
+
+                if (TextArea.IndentationStrategy == null)
+                {
+                    TextArea.IndentationStrategy = new DefaultIndentationStrategy();
+                }
 
                 LanguageService.Diagnostics?.ObserveOn(AvaloniaScheduler.Instance).Subscribe(d =>
                 {

--- a/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/CodeEditor.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/CodeEditor.cs
@@ -15,6 +15,7 @@ using AvalonStudio.CodeEditor;
 using AvalonStudio.Controls.Standard.CodeEditor.Snippets;
 using AvalonStudio.Debugging;
 using AvalonStudio.Extensibility;
+using AvalonStudio.Extensibility.Documents;
 using AvalonStudio.Extensibility.Editor;
 using AvalonStudio.Extensibility.Threading;
 using AvalonStudio.GlobalSettings;
@@ -296,6 +297,8 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
                             {
                                 FileName = file.Item2.Location
                             };
+
+                            DocumentAccessor = new CodeEditorDocumentAdaptor(this);
                         }
                     }
 
@@ -984,6 +987,15 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
         {
             get => GetValue(SourceTextProperty);
             set => SetValue(SourceTextProperty, value);
+        }
+
+        public static readonly AvaloniaProperty<ITextDocument> DocumentAccessorProperty = 
+            AvaloniaProperty.Register<CodeEditor, ITextDocument>(nameof(DocumentAccessor), defaultBindingMode: BindingMode.TwoWay);
+
+        public ITextDocument DocumentAccessor
+        {
+            get => GetValue(DocumentAccessorProperty);
+            set => SetValue(DocumentAccessorProperty, value);
         }
 
         public static readonly StyledProperty<bool> IsDirtyProperty =

--- a/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/Completion/CompletionDataViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/Completion/CompletionDataViewModel.cs
@@ -1,6 +1,4 @@
-using Avalonia.Controls;
 using Avalonia.Media;
-using Avalonia.Media.Imaging;
 using AvalonStudio.Languages;
 using AvalonStudio.MVVM;
 
@@ -38,7 +36,7 @@ namespace AvalonStudio.Controls.Standard.CodeEditor.Completion
 
         public string Title
         {
-            get { return Model.Suggestion; }
+            get { return Model.DisplayText; }
         }
 
         public uint Priority
@@ -55,7 +53,7 @@ namespace AvalonStudio.Controls.Standard.CodeEditor.Completion
 
         public string Hint
         {
-            get { return Model?.Hint; }
+            get { return Model?.DisplayText; }
         }
 
         public string Comment

--- a/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/Intellisense.paml.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/Intellisense.paml.cs
@@ -49,11 +49,15 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
         protected override void OnAttachedToVisualTree(VisualTreeAttachmentEventArgs e)
         {
             disposables.Add(RequestBringIntoViewEvent.AddClassHandler<Intellisense>(i => OnRequesteBringIntoView));
+
+            base.OnAttachedToVisualTree(e);
         }
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
             disposables.Dispose();
+
+            base.OnDetachedFromVisualTree(e);
         }
 
         private void OnRequesteBringIntoView(RequestBringIntoViewEventArgs e)

--- a/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/IntellisenseManager.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/IntellisenseManager.cs
@@ -134,7 +134,7 @@
                 {
                     CompletionDataViewModel currentCompletion = null;
 
-                    currentCompletion = unfilteredCompletions.BinarySearch(c => c.Title, result.Suggestion);
+                    currentCompletion = unfilteredCompletions.BinarySearch(c => c.Title, result.DisplayText);
 
                     if (currentCompletion == null)
                     {
@@ -302,9 +302,16 @@
                 if (caretIndex - wordStart - offset >= 0 && intellisenseControl.SelectedCompletion != null)
                 {
                     editor.Document.Replace(wordStart, caretIndex - wordStart - offset,
-                            intellisenseControl.SelectedCompletion.Title);
+                            intellisenseControl.SelectedCompletion.Model.InsertionText);
 
-                    caretIndex = wordStart + intellisenseControl.SelectedCompletion.Title.Length + offset;
+                    var length = intellisenseControl.SelectedCompletion.Model.InsertionText.Length;
+
+                    if(intellisenseControl.SelectedCompletion.Model.RecommendedCaretPosition.HasValue)
+                    {
+                        length = intellisenseControl.SelectedCompletion.Model.RecommendedCaretPosition.Value;
+                    }
+
+                    caretIndex = wordStart + length + offset;
 
                     editor.CaretOffset = caretIndex;
                 }
@@ -324,7 +331,7 @@
         {
             foreach (var snippet in _snippets)
             {
-                var current = sortedResults.InsertSortedExclusive(new CodeCompletionData { Kind = CodeCompletionKind.Snippet, Suggestion = snippet.Name, BriefComment = snippet.Description });
+                var current = sortedResults.InsertSortedExclusive(new CodeCompletionData (snippet.Name, snippet.Name) { Kind = CodeCompletionKind.Snippet, BriefComment = snippet.Description });
 
                 if (current != null && current.Kind != CodeCompletionKind.Snippet)
                 {

--- a/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/LineNumberMargin.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/LineNumberMargin.cs
@@ -15,7 +15,7 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
     /// <summary>
     /// Margin showing line numbers.
     /// </summary>
-    public class LineNumberMargin : AbstractMargin
+    public class LineNumberMargin : AbstractMargin, IDisposable
     {
         private TextArea _textArea;
         private CodeEditor _editor;
@@ -243,6 +243,12 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
                 e.Handled = true;
             }
             base.OnPointerReleased(e);
+        }
+
+        public void Dispose()
+        {
+            _editor = null;
+            _textArea = null;
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Controls.Standard/Console/ConsoleView.paml
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/Console/ConsoleView.paml
@@ -1,5 +1,10 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui" xmlns:cont="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio.Extensibility" xmlns:editor="clr-namespace:AvalonStudio.Controls.Standard.CodeEditor;assembly=AvalonStudio.Controls.Standard">
   <cont:ToolControl Title="Console">
-    
+    <editor:CodeEditor Grid.Row="1" BorderThickness="0" Background="{DynamicResource ThemeControlBackgroundBrush}" 
+                       TextBlock.FontFamily="Consolas" TextBlock.FontSize="13"
+                       Document="{Binding Document}" EditorCaretOffset="{Binding CaretIndex, Mode=TwoWay}" 
+                       BackgroundRenderers="{Binding BackgroundRenderers}" 
+                       LineNumbersVisible="false" ShowBreakpoints="false" IsReadOnly="true"
+                       HighlightSelectedLine="false" HighlightSelectedWord="false" />
   </cont:ToolControl>
 </UserControl>

--- a/AvalonStudio/AvalonStudio.Controls.Standard/Console/ConsoleView.paml
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/Console/ConsoleView.paml
@@ -1,10 +1,5 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui" xmlns:cont="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio.Extensibility" xmlns:editor="clr-namespace:AvalonStudio.Controls.Standard.CodeEditor;assembly=AvalonStudio.Controls.Standard">
   <cont:ToolControl Title="Console">
-    <editor:CodeEditor Grid.Row="1" BorderThickness="0" Background="{DynamicResource ThemeControlBackgroundBrush}" 
-                       TextBlock.FontFamily="Consolas" TextBlock.FontSize="13"
-                       Document="{Binding Document}" EditorCaretOffset="{Binding CaretIndex, Mode=TwoWay}" 
-                       BackgroundRenderers="{Binding BackgroundRenderers}" 
-                       LineNumbersVisible="false" ShowBreakpoints="false" IsReadOnly="true"
-                       HighlightSelectedLine="false" HighlightSelectedWord="false" />
+    
   </cont:ToolControl>
 </UserControl>

--- a/AvalonStudio/AvalonStudio.Controls.Standard/SolutionExplorer/ProjectConfigurationDialogViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/SolutionExplorer/ProjectConfigurationDialogViewModel.cs
@@ -23,9 +23,9 @@ namespace AvalonStudio.Controls.Standard.SolutionExplorer
             _onClose = onClose;
         }
 
-        public override void OnClose()
+        public override void Close()
         {
-            base.OnClose();
+            base.Close();
 
             _onClose?.Invoke();
         }

--- a/AvalonStudio/AvalonStudio.Debugging/DisassemblyView.paml
+++ b/AvalonStudio/AvalonStudio.Debugging/DisassemblyView.paml
@@ -6,11 +6,7 @@
         <TextBlock Text="Mixed Mode" />
         <CheckBox IsChecked="{Binding MixedMode}" />
       </StackPanel>
-      <editor:CodeEditor Grid.Row="1" BorderThickness="0" Background="{DynamicResource ThemeControlDarkBrush}" TextBlock.FontFamily="Consolas"
-                       TextBlock.FontSize="13" TextBlock.FontWeight="100" TextBlock.Foreground="#D4D4D4" Document="{Binding Document}"
-                       EditorCaretOffset="{Binding CaretIndex, Mode=TwoWay}" BackgroundRenderers="{Binding BackgroundRenderers}"
-                       DocumentLineTransformers="{Binding LineTransformers}"
-                       LineNumbersVisible="false" ShowBreakpoints="false" IsReadOnly="true" HighlightSelectedLine="false" HighlightSelectedWord="false" />
+      
     </DockPanel>
   </cont:ToolControl>
 </UserControl>

--- a/AvalonStudio/AvalonStudio.Extensibility/AvalonStudio.Extensibility.csproj
+++ b/AvalonStudio/AvalonStudio.Extensibility/AvalonStudio.Extensibility.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <RootNamespace>AvalonStudio.Extensibility</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/EditableTextBlock.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/EditableTextBlock.cs
@@ -66,12 +66,7 @@ namespace AvalonStudio.Controls
             base.OnTemplateApplied(e);
 
             _textBox = e.NameScope.Find<TextBox>("PART_TextBox");
-        }
-
-        protected override void OnDetachedFromLogicalTree(LogicalTreeAttachmentEventArgs e)
-        {
-            base.OnDetachedFromLogicalTree(e);
-        }
+        }        
 
         protected override void OnKeyUp(KeyEventArgs e)
         {

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/ViewLocatorDataTemplate.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/ViewLocatorDataTemplate.cs
@@ -1,0 +1,31 @@
+﻿using Avalonia.Controls;
+using Avalonia.Controls.Templates;
+using System;
+
+namespace AvalonStudio.Controls
+{
+    public class ViewLocatorDataTemplate : IDataTemplate
+    {
+        public bool SupportsRecycling => throw new System.NotImplementedException();
+
+        public IControl Build(object data)
+        {
+            var name = data.GetType().FullName.Replace("ViewModel", "View");
+            var type = Type.GetType(name);
+
+            if (type != null)
+            {
+                return (Control)Activator.CreateInstance(type);
+            }
+            else
+            {
+                return new TextBlock { Text = name };
+            }
+        }
+
+        public bool Match(object data)
+        {
+            return true;
+        }
+    }
+}

--- a/AvalonStudio/AvalonStudio.Extensibility/Controls/ViewLocatorDataTemplate.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Controls/ViewLocatorDataTemplate.cs
@@ -6,7 +6,7 @@ namespace AvalonStudio.Controls
 {
     public class ViewLocatorDataTemplate : IDataTemplate
     {
-        public bool SupportsRecycling => throw new System.NotImplementedException();
+        public bool SupportsRecycling => false;
 
         public IControl Build(object data)
         {
@@ -15,12 +15,18 @@ namespace AvalonStudio.Controls
 
             if (type != null)
             {
-                return (Control)Activator.CreateInstance(type);
+                if (typeof(Control).IsAssignableFrom(type))
+                {
+                    var constructor = type.GetConstructor(Type.EmptyTypes);
+
+                    if (constructor != null)
+                    {
+                        return (Control)Activator.CreateInstance(type);
+                    }
+                }                
             }
-            else
-            {
-                return new TextBlock { Text = name };
-            }
+            
+            return new TextBlock { Text = name };            
         }
 
         public bool Match(object data)

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/EditorViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/EditorViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using AvalonStudio.Projects;
 using ReactiveUI;
+using System;
 
 namespace AvalonStudio.Controls
 {
@@ -11,6 +12,11 @@ namespace AvalonStudio.Controls
         public EditorViewModel(ISourceFile file)
         {            
             _sourceFile = file;            
+        }
+
+        ~EditorViewModel()
+        {
+            Console.WriteLine("Dispose VM");
         }
 
         public bool IsDirty

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/EditorViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/EditorViewModel.cs
@@ -1,39 +1,16 @@
-﻿using Avalonia.Input;
-using AvalonStudio.Extensibility.Documents;
-using AvalonStudio.Projects;
+﻿using AvalonStudio.Projects;
 using ReactiveUI;
-using System;
-using System.Reactive.Disposables;
-using System.Reactive.Linq;
 
 namespace AvalonStudio.Controls
 {
     public abstract class EditorViewModel : DocumentTabViewModel, IFileDocumentTabViewModel
     {
         private bool _isDirty;
-        private ISourceFile _sourceFile;
-        private ITextDocument _documentAccessor;
-        private CompositeDisposable _disposables;
+        private ISourceFile _sourceFile;                
 
         public EditorViewModel(ISourceFile file)
         {            
-            _sourceFile = file;
-
-            this.WhenAnyValue(x => x.DocumentAccessor).Subscribe(accessor =>
-            {
-                _disposables?.Dispose();
-                _disposables = null;
-
-                if(accessor != null)
-                {
-                    _disposables = new CompositeDisposable();
-
-                    _disposables.Add(Observable.FromEventPattern<TextInputEventArgs>(accessor, nameof(accessor.TextEntered)).Subscribe(args =>
-                    {
-                        IsDirty = true;
-                    }));
-                }
-            });
+            _sourceFile = file;            
         }
 
         public bool IsDirty
@@ -49,11 +26,9 @@ namespace AvalonStudio.Controls
                 }
             }
         }
-
+        
         public override void Save()
         {
-            _documentAccessor?.Save();
-
             IsDirty = false;
         }
 
@@ -61,12 +36,6 @@ namespace AvalonStudio.Controls
         {
             get { return _sourceFile; }
             set { this.RaiseAndSetIfChanged(ref _sourceFile, value); }
-        }
-
-        public ITextDocument DocumentAccessor
-        {
-            get { return _documentAccessor; }
-            set { this.RaiseAndSetIfChanged(ref _documentAccessor, value); }
-        }
+        }        
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/EditorViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/EditorViewModel.cs
@@ -19,11 +19,6 @@ namespace AvalonStudio.Controls
         {            
             _sourceFile = file;
 
-            SaveCommand = ReactiveCommand.Create(() =>
-            {
-                Save(); 
-            });
-
             this.WhenAnyValue(x => x.DocumentAccessor).Subscribe(accessor =>
             {
                 _disposables?.Dispose();
@@ -73,7 +68,5 @@ namespace AvalonStudio.Controls
             get { return _documentAccessor; }
             set { this.RaiseAndSetIfChanged(ref _documentAccessor, value); }
         }
-
-        public ReactiveCommand SaveCommand { get; }
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/GenericDocumentTabViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/GenericDocumentTabViewModel.cs
@@ -32,6 +32,11 @@ namespace AvalonStudio.Controls
             set { this.RaiseAndSetIfChanged(ref dock, value); }
         }
 
+        public virtual void Save()
+        {
+
+        }
+
         public ReactiveCommand CloseCommand { get; protected set; }
 
         public string Title

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/GenericDocumentTabViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/GenericDocumentTabViewModel.cs
@@ -16,11 +16,6 @@ namespace AvalonStudio.Controls
 
         public DocumentTabViewModel(T model) : base(model)
         {
-            CloseCommand = ReactiveCommand.Create(() =>
-            {
-                IoC.Get<IShell>().RemoveDocument(this);
-            });
-
             Dock = Dock.Left;
 
             IsVisible = true;
@@ -35,9 +30,7 @@ namespace AvalonStudio.Controls
         public virtual void Save()
         {
 
-        }
-
-        public ReactiveCommand CloseCommand { get; protected set; }
+        }        
 
         public string Title
         {
@@ -81,8 +74,9 @@ namespace AvalonStudio.Controls
             set { this.RaiseAndSetIfChanged(ref _isSelected, value); }
         }
 
-        public virtual void OnClose()
+        public virtual void Close()
         {
+            IoC.Get<IShell>().RemoveDocument(this);
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/IDocumentTabViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/IDocumentTabViewModel.cs
@@ -26,5 +26,7 @@ namespace AvalonStudio.Controls
         Dock Dock { get; set; }
 
         void OnClose();
+
+        void Save();
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/IDocumentTabViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/IDocumentTabViewModel.cs
@@ -1,6 +1,4 @@
-﻿using Avalonia.Controls;
-using AvalonStudio.Projects;
-using ReactiveUI;
+﻿using AvalonStudio.Projects;
 
 namespace AvalonStudio.Controls
 {
@@ -9,24 +7,14 @@ namespace AvalonStudio.Controls
         ISourceFile SourceFile { get; }
 
         bool IsDirty { get; set; }
+
+        void Save();
     }
 
     public interface IDocumentTabViewModel
     {
         string Title { get; set; }
 
-        ReactiveCommand CloseCommand { get; }
-
-        bool IsTemporary { get; set; }
-
-        bool IsVisible { get; set; }
-
-        bool IsSelected { get; set; }
-
-        Dock Dock { get; set; }
-
-        void OnClose();
-
-        void Save();
+        void Close();
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/ITextDocument.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/ITextDocument.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Avalonia.Input;
+using System;
 using System.Collections.Generic;
 using System.Text;
 
@@ -6,6 +7,18 @@ namespace AvalonStudio.Extensibility.Documents
 {
     public interface ITextDocument
     {
+        /// <summary>
+        /// Occurs when the TextArea receives text input.
+        /// but occurs immediately before the TextArea handles the TextInput event.
+        /// </summary>
+        event EventHandler<TextInputEventArgs> TextEntering;
+
+        /// <summary>
+        /// Occurs when the TextArea receives text input.
+        /// but occurs immediately after the TextArea handles the TextInput event.
+        /// </summary>
+        event EventHandler<TextInputEventArgs> TextEntered;
+
         void Save();
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/ITextDocument.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/ITextDocument.cs
@@ -1,10 +1,138 @@
 ﻿using Avalonia.Input;
 using System;
+using System.Collections.Generic;
 
 namespace AvalonStudio.Extensibility.Documents
 {
-    public interface ITextDocument : IDisposable
+    public static class ITextDocumentExtensions
     {
+        public static void TrimTrailingWhiteSpace(this ITextDocument document, ISegment line)
+        {
+            document.Replace(line, document.GetText(line).TrimEnd());
+        }
+
+        public static void TrimTrailingWhiteSpace(this ITextDocument document, int lineNumber)
+        {
+            var line = document.Lines[lineNumber];
+            document.TrimTrailingWhiteSpace(line);
+        }
+
+        public static void TrimTrailingWhiteSpace(this ITextDocument document)
+        {
+            using (document.RunUpdate())
+            {
+                foreach (var line in document.Lines)
+                {
+                    document.Replace(line, document.GetText(line).TrimEnd());
+                }
+            }
+        }
+
+        public static string GetText (this ITextDocument document, ISegment segment)
+        {
+            return document.GetText(segment.Offset, segment.Length);
+        }
+
+        public static void Replace (this ITextDocument document, ISegment segment, string text)
+        {
+            document.Replace(segment.Offset, segment.Length, text);
+        }
+    }
+
+    /// <summary>
+    /// An (Offset,Length)-pair.
+    /// </summary>
+    public interface ISegment
+    {
+        /// <summary>
+        /// Gets the start offset of the segment.
+        /// </summary>
+        int Offset { get; }
+
+        /// <summary>
+        /// Gets the length of the segment.
+        /// </summary>
+        /// <remarks>For line segments (IDocumentLine), the length does not include the line delimeter.</remarks>
+        int Length { get; }
+
+        /// <summary>
+        /// Gets the end offset of the segment.
+        /// </summary>
+        /// <remarks>EndOffset = Offset + Length;</remarks>
+        int EndOffset { get; }
+    }
+
+    /// <summary>
+    /// A line inside a <see cref="IDocument"/>.
+    /// </summary>
+    public interface IDocumentLine : ISegment
+    {
+        /// <summary>
+        /// Gets the length of this line, including the line delimiter.
+        /// </summary>
+        int TotalLength { get; }
+
+        /// <summary>
+        /// Gets the length of the line terminator.
+        /// Returns 1 or 2; or 0 at the end of the document.
+        /// </summary>
+        int DelimiterLength { get; }
+
+        /// <summary>
+        /// Gets the number of this line.
+        /// The first line has the number 1.
+        /// </summary>
+        int LineNumber { get; }
+
+        /// <summary>
+        /// Gets the previous line. Returns null if this is the first line in the document.
+        /// </summary>
+        IDocumentLine PreviousLine { get; }
+
+        /// <summary>
+        /// Gets the next line. Returns null if this is the last line in the document.
+        /// </summary>
+        IDocumentLine NextLine { get; }
+    }
+
+    public interface IIndexableList<T> : IEnumerable<T>
+    {
+        T this[int index] { get; }
+
+        int Count { get; }
+    }
+
+    public interface ITextDocument
+    {
+        void Insert(int offset, string text);
+
+        void Replace(int offset, int length, string text);
+
+        string Text { get; }
+
+        IIndexableList<IDocumentLine> Lines { get; }
+
+        int LineCount { get; }
+
+        string GetText(int offset, int length);
+
+        IDisposable RunUpdate();
+    }
+
+    public interface IEditor : IDisposable
+    {
+        int Offset { get; set; }
+
+        int Line { get; set; }
+
+        int Column { get; set; }
+
+        ITextDocument Document { get; }
+
+        void Save();
+
+        void IndentLine(int line);
+
         /// <summary>
         /// Occurs when the TextArea receives text input.
         /// but occurs immediately before the TextArea handles the TextInput event.
@@ -16,13 +144,5 @@ namespace AvalonStudio.Extensibility.Documents
         /// but occurs immediately after the TextArea handles the TextInput event.
         /// </summary>
         event EventHandler<TextInputEventArgs> TextEntered;
-
-        void Save();
-
-        void Replace(int offset, int length, string text);
-
-        string Text { get; }
-
-        int Caret { get; set; }
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/ITextDocument.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/ITextDocument.cs
@@ -37,6 +37,20 @@ namespace AvalonStudio.Extensibility.Documents
         {
             document.Replace(segment.Offset, segment.Length, text);
         }
+
+        public static ISegment GetWhitespaceAfter(this ITextDocument textSource, int offset)
+        {
+            if (textSource == null)
+                throw new ArgumentNullException(nameof(textSource));
+            int pos;
+            for (pos = offset; pos < textSource.TextLength; pos++)
+            {
+                char c = textSource.GetCharAt(pos);
+                if (c != ' ' && c != '\t')
+                    break;
+            }
+            return new SimpleSegment(offset, pos - offset);
+        }
     }
 
     /// <summary>
@@ -110,11 +124,15 @@ namespace AvalonStudio.Extensibility.Documents
 
         string Text { get; }
 
+        int TextLength { get; }
+
         IIndexableList<IDocumentLine> Lines { get; }
 
         int LineCount { get; }
 
         string GetText(int offset, int length);
+
+        char GetCharAt(int offset);
 
         IDisposable RunUpdate();
     }

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/ITextDocument.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/ITextDocument.cs
@@ -1,11 +1,9 @@
 ﻿using Avalonia.Input;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace AvalonStudio.Extensibility.Documents
 {
-    public interface ITextDocument
+    public interface ITextDocument : IDisposable
     {
         /// <summary>
         /// Occurs when the TextArea receives text input.
@@ -20,5 +18,11 @@ namespace AvalonStudio.Extensibility.Documents
         event EventHandler<TextInputEventArgs> TextEntered;
 
         void Save();
+
+        void Replace(int offset, int length, string text);
+
+        string Text { get; }
+
+        int Caret { get; set; }
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Documents/SimpleSegment.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Documents/SimpleSegment.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Diagnostics;
+
+namespace AvalonStudio.Extensibility.Documents
+{
+    public struct SimpleSegment : IEquatable<SimpleSegment>, ISegment
+    {
+        public static readonly SimpleSegment Invalid = new SimpleSegment(-1, -1);
+
+        /// <summary>
+        /// Gets the overlapping portion of the segments.
+        /// Returns SimpleSegment.Invalid if the segments don't overlap.
+        /// </summary>
+        public static SimpleSegment GetOverlap(ISegment segment1, ISegment segment2)
+        {
+            var start = Math.Max(segment1.Offset, segment2.Offset);
+            var end = Math.Min(segment1.EndOffset, segment2.EndOffset);
+            return end < start ? Invalid : new SimpleSegment(start, end - start);
+        }
+
+        public readonly int Offset, Length;
+
+        int ISegment.Offset => Offset;
+
+        int ISegment.Length => Length;
+
+        public int EndOffset => Offset + Length;
+
+        public SimpleSegment(int offset, int length)
+        {
+            Offset = offset;
+            Length = length;
+        }
+
+        public SimpleSegment(ISegment segment)
+        {
+            Debug.Assert(segment != null);
+            Offset = segment.Offset;
+            Length = segment.Length;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                return Offset + 10301 * Length;
+            }
+        }
+
+        public override bool Equals(object obj)
+        {
+            return (obj is SimpleSegment) && Equals((SimpleSegment)obj);
+        }
+
+        public bool Equals(SimpleSegment other)
+        {
+            return Offset == other.Offset && Length == other.Length;
+        }
+
+        public static bool operator ==(SimpleSegment left, SimpleSegment right)
+        {
+            return left.Equals(right);
+        }
+
+        public static bool operator !=(SimpleSegment left, SimpleSegment right)
+        {
+            return !left.Equals(right);
+        }
+
+        /// <inheritdoc/>
+        public override string ToString()
+        {
+            return $"[Offset={Offset}, Length={Length}]";
+        }
+    }
+}

--- a/AvalonStudio/AvalonStudio.Extensibility/Editor/EditorView.xaml
+++ b/AvalonStudio/AvalonStudio.Extensibility/Editor/EditorView.xaml
@@ -6,27 +6,24 @@
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
              xmlns:actions="clr-namespace:AvalonStudio.Actions;assembly=AvalonStudio"
              xmlns:editor="clr-namespace:AvalonStudio.Controls.Standard.CodeEditor;assembly=AvalonStudio.Controls.Standard" Name="Editor">
-    <Border BorderBrush="{DynamicResource ThemeBorderDarkBrush}" BorderThickness="1">
-        <Grid>
-            <DockPanel>
-                <Grid DockPanel.Dock="Bottom" Margin="10 0 0 0">
-                    <TextBlock Text="{Binding ZoomLevelText}" FontSize="10" />
-                </Grid>
+    <Grid>
+        <DockPanel>
+            <Grid DockPanel.Dock="Bottom" Margin="10 0 0 0">
+                <TextBlock Text="{Binding ZoomLevelText}" FontSize="10" />
+            </Grid>
 
-                <editor:CodeEditor Name="editor"
+            <editor:CodeEditor Name="editor"
                                    BorderThickness="0" Margin="0"
                                    VerticalAlignment="Stretch"
-                                   Background="{DynamicResource ThemeEditorBackground}"
-                                   
+                                   Background="{DynamicResource ThemeEditorBackground}"                                   
                                    FontFamily="{Binding FontFamily}" 
-                                   FontSize="{Binding VisualFontSize}"
-                                  
-                                  SourceFile="{Binding SourceFile}" 
-                                  IsDirty="{Binding IsDirty}"
-                                   
+                                   FontSize="{Binding VisualFontSize}"                                  
+                                   SourceFile="{Binding SourceFile}" 
+                                   IsDirty="{Binding IsDirty}"
+                                   SourceText="{Binding SourceText}"                                   
+                                   HighlightSelectedWord="False"                   
                                    DocumentAccessor="{Binding DocumentAccessor}">
-                </editor:CodeEditor>
-            </DockPanel>
-        </Grid>
-    </Border>
+            </editor:CodeEditor>
+        </DockPanel>
+    </Grid>
 </UserControl>

--- a/AvalonStudio/AvalonStudio.Extensibility/Editor/EditorView.xaml
+++ b/AvalonStudio/AvalonStudio.Extensibility/Editor/EditorView.xaml
@@ -6,6 +6,10 @@
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
              xmlns:actions="clr-namespace:AvalonStudio.Actions;assembly=AvalonStudio"
              xmlns:editor="clr-namespace:AvalonStudio.Controls.Standard.CodeEditor;assembly=AvalonStudio.Controls.Standard" Name="Editor">
+    <UserControl.KeyBindings>
+        <KeyBinding Command="{Binding SaveCommand}" Gesture="CTRL+S" />
+    </UserControl.KeyBindings>
+    
     <Border BorderBrush="{DynamicResource ThemeBorderDarkBrush}" BorderThickness="1">
         <Grid>
             <DockPanel>
@@ -22,7 +26,9 @@
                                    FontSize="{Binding VisualFontSize}"
                                   
                                   SourceFile="{Binding SourceFile}" 
-                                  IsDirty="{Binding IsDirty}">
+                                  IsDirty="{Binding IsDirty}"
+                                   
+                                   DocumentAccessor="{Binding DocumentAccessor}">
                 </editor:CodeEditor>
             </DockPanel>
         </Grid>

--- a/AvalonStudio/AvalonStudio.Extensibility/Editor/EditorView.xaml
+++ b/AvalonStudio/AvalonStudio.Extensibility/Editor/EditorView.xaml
@@ -6,10 +6,6 @@
              xmlns:i="clr-namespace:Avalonia.Xaml.Interactivity;assembly=Avalonia.Xaml.Interactivity"
              xmlns:actions="clr-namespace:AvalonStudio.Actions;assembly=AvalonStudio"
              xmlns:editor="clr-namespace:AvalonStudio.Controls.Standard.CodeEditor;assembly=AvalonStudio.Controls.Standard" Name="Editor">
-    <UserControl.KeyBindings>
-        <KeyBinding Command="{Binding SaveCommand}" Gesture="CTRL+S" />
-    </UserControl.KeyBindings>
-    
     <Border BorderBrush="{DynamicResource ThemeBorderDarkBrush}" BorderThickness="1">
         <Grid>
             <DockPanel>

--- a/AvalonStudio/AvalonStudio.Extensibility/Editor/EditorView.xaml.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Editor/EditorView.xaml.cs
@@ -10,6 +10,12 @@ namespace AvalonStudio.Extensibility.Editor
         {
             InitializeComponent();
         }
+
+        ~EditorView ()
+        {
+            System.Console.WriteLine("EditorView Disposed");
+        }
+
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);
@@ -17,6 +23,8 @@ namespace AvalonStudio.Extensibility.Editor
 
         protected override void OnAttachedToLogicalTree(LogicalTreeAttachmentEventArgs e)
         {
+            base.OnAttachedToLogicalTree(e);
+
             /* _editor = this.FindControl<Standard.CodeEditor.CodeEditor>("editor");
 
              _editor.RequestTooltipContent += _editor_RequestTooltipContent;

--- a/AvalonStudio/AvalonStudio.Extensibility/Editor/ICodeEditorInputHelper.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Editor/ICodeEditorInputHelper.cs
@@ -1,0 +1,15 @@
+﻿using Avalonia.Input;
+using AvalonStudio.Extensibility.Documents;
+using AvalonStudio.Languages;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AvalonStudio.Editor
+{
+    public interface ICodeEditorInputHelper
+    {
+        void BeforeTextInput(ILanguageService languageService, ITextDocument document, TextInputEventArgs args);
+        void AfterTextInput(ILanguageService languageServivce, ITextDocument document, TextInputEventArgs args);
+    }
+}

--- a/AvalonStudio/AvalonStudio.Extensibility/Editor/ICodeEditorInputHelper.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Editor/ICodeEditorInputHelper.cs
@@ -9,7 +9,7 @@ namespace AvalonStudio.Editor
 {
     public interface ICodeEditorInputHelper
     {
-        void BeforeTextInput(ILanguageService languageService, ITextDocument document, TextInputEventArgs args);
-        void AfterTextInput(ILanguageService languageServivce, ITextDocument document, TextInputEventArgs args);
+        void BeforeTextInput(ILanguageService languageService, IEditor document, TextInputEventArgs args);
+        void AfterTextInput(ILanguageService languageServivce, IEditor document, TextInputEventArgs args);
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Editor/TextEditorView.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Editor/TextEditorView.cs
@@ -9,6 +9,12 @@ namespace AvalonStudio.Extensibility.Editor
         {
             InitializeComponent();
         }
+
+        ~TextEditorView ()
+        {
+            System.Console.WriteLine("TextEditorView disposed");
+        }
+
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);

--- a/AvalonStudio/AvalonStudio.Extensibility/Editor/TextEditorViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Editor/TextEditorViewModel.cs
@@ -19,7 +19,7 @@ namespace AvalonStudio.Extensibility.Editor
         private double _visualFontSize;
         private IShell _shell;
         private string _sourceText;
-        private ITextDocument _documentAccessor;
+        private IEditor _documentAccessor;
         private CompositeDisposable _disposables;
 
         public TextEditorViewModel(ISourceFile file) : base(file)
@@ -126,7 +126,7 @@ namespace AvalonStudio.Extensibility.Editor
             VisualFontSize = (ZoomLevel / 100) * FontSize;
         }
 
-        public ITextDocument DocumentAccessor
+        public IEditor DocumentAccessor
         {
             get { return _documentAccessor; }
             set { this.RaiseAndSetIfChanged(ref _documentAccessor, value); }

--- a/AvalonStudio/AvalonStudio.Extensibility/Editor/TextEditorViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Editor/TextEditorViewModel.cs
@@ -48,6 +48,11 @@ namespace AvalonStudio.Extensibility.Editor
             //ZoomLevel = _shell.GlobalZoomLevel;
         }
 
+        ~TextEditorViewModel()
+        {
+            System.Console.WriteLine("TextEditorVM Disposed");
+        }
+
         public string SourceText
         {
             get { return _sourceText; }

--- a/AvalonStudio/AvalonStudio.Extensibility/Languages/CodeCompletionData.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Languages/CodeCompletionData.cs
@@ -81,6 +81,8 @@ namespace AvalonStudio.Languages
             RecommendedCaretPosition = recommendedCaretOffset;
         }
 
+        public bool RecommendImmediateSuggestions { get; set; }
+
         public uint Priority { get; set; }
 
         public string DisplayText { get; set; }

--- a/AvalonStudio/AvalonStudio.Extensibility/Languages/CodeCompletionData.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Languages/CodeCompletionData.cs
@@ -72,33 +72,34 @@ namespace AvalonStudio.Languages
         Snippet
     }
 
-    public class CodeCompletionData : ICompletionData, IComparable<CodeCompletionData>
+    public class CodeCompletionData : IComparable<CodeCompletionData>
     {
+        public CodeCompletionData(string displayText, string insertionText, int? recommendedCaretOffset = null)
+        {
+            DisplayText = displayText;
+            InsertionText = insertionText;
+            RecommendedCaretPosition = recommendedCaretOffset;
+        }
+
         public uint Priority { get; set; }
-        public string Suggestion { get; set; }
-        public CodeCompletionKind Kind { get; set; }
-        public string Hint { get; set; }
+
+        public string DisplayText { get; set; }
+
+        public string InsertionText { get; set; }
+
         public string BriefComment { get; set; }
+
+        public int? RecommendedCaretPosition { get; set; }
+
+        public CodeCompletionKind Kind { get; set; }
+
         public int Overloads { get; set; }
 
         public IBitmap Image => null;
 
-        public string Text => Suggestion;
-
-        public object Content => Text; // Could show a ui element here instead! Future use! 
-
-        public object Description => BriefComment;
-
-        double ICompletionData.Priority => (double)Priority;
-
         public int CompareTo(CodeCompletionData other)
         {
-            return Text.CompareTo(other.Text);
-        }
-
-        public void Complete(TextArea textArea, ISegment completionSegment, EventArgs insertionRequestEventArgs)
-        {
-            textArea.Document.Replace(completionSegment, Text);
+            return DisplayText.CompareTo(other.DisplayText);
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Extensibility/Languages/ILanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Languages/ILanguageService.cs
@@ -1,5 +1,6 @@
 using AvaloniaEdit.Document;
 using AvaloniaEdit.Indentation;
+using AvalonStudio.Editor;
 using AvalonStudio.Extensibility.Languages.CompletionAssistance;
 using AvalonStudio.Extensibility.Plugin;
 using AvalonStudio.Projects;
@@ -45,6 +46,7 @@ namespace AvalonStudio.Languages
         bool CanTriggerIntellisense(char currentChar, char previousChar);
         IEnumerable<char> IntellisenseSearchCharacters { get; }
         IEnumerable<char> IntellisenseCompleteCharacters { get; }
+        IEnumerable<ICodeEditorInputHelper> InputHelpers { get; }        
 
         bool IsValidIdentifierCharacter(char data);
 

--- a/AvalonStudio/AvalonStudio.Extensibility/MVVM/ViewLocator.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/MVVM/ViewLocator.cs
@@ -11,7 +11,7 @@ namespace AvalonStudio.MVVM
         {
             var name = data.GetType().FullName.Replace("ViewModel", "View");
 
-            var assemblies = AvalonStudio.Extensibility.Utils.AppDomain.CurrentDomain.GetAssemblies().Where(a => name.Contains(a.GetName().Name));
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies().Where(a => name.Contains(a.GetName().Name));
 
             Type type = null;
 

--- a/AvalonStudio/AvalonStudio.Extensibility/Threading/JobRunner.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Threading/JobRunner.cs
@@ -24,7 +24,10 @@ namespace AvalonStudio.Extensibility.Threading
 
         public void RunLoop(CancellationToken cancellationToken)
         {
-            cancellationToken.Register(() => { _event.Set(); });
+            cancellationToken.Register(() =>
+            {
+                _event.Set();
+            });
 
             while (!cancellationToken.IsCancellationRequested)
             {

--- a/AvalonStudio/AvalonStudio.LanguageSupport.TypeScript/LanguageService/TypeScriptLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.LanguageSupport.TypeScript/LanguageService/TypeScriptLanguageService.cs
@@ -1,6 +1,7 @@
 ﻿using AvaloniaEdit.Document;
 using AvaloniaEdit.Indentation;
 using AvaloniaEdit.Rendering;
+using AvalonStudio.Editor;
 using AvalonStudio.Extensibility.Languages.CompletionAssistance;
 using AvalonStudio.Languages;
 using AvalonStudio.LanguageSupport.TypeScript.Projects;
@@ -32,6 +33,8 @@ namespace AvalonStudio.LanguageSupport.TypeScript.LanguageService
             new ConditionalWeakTable<ISourceFile, TypeScriptDataAssociation>();
 
         public Type BaseTemplateType => typeof(BlankTypeScriptProjectTemplate);
+
+        public IEnumerable<ICodeEditorInputHelper> InputHelpers => null;
 
         public bool CanTriggerIntellisense(char currentChar, char previousChar)
         {

--- a/AvalonStudio/AvalonStudio.LanguageSupport.TypeScript/LanguageService/TypeScriptLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.LanguageSupport.TypeScript/LanguageService/TypeScriptLanguageService.cs
@@ -150,12 +150,10 @@ namespace AvalonStudio.LanguageSupport.TypeScript.LanguageService
 
             var editorCompletions = completions.Entries.Select(cc =>
                 {
-                    var ccData = new CodeCompletionData
+                    var ccData = new CodeCompletionData (cc.Name, cc.Name)
                     {
                         Kind = ConvertCodeCompletionKind(cc.Kind),
-                        Hint = cc.KindModifiers,
-                        BriefComment = cc.Name,
-                        Suggestion = cc.Name
+                        BriefComment = cc.Name
                     };
                     return ccData;
                 })

--- a/AvalonStudio/AvalonStudio.Languages.CPlusPlus/CPlusPlusLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.CPlusPlus/CPlusPlusLanguageService.cs
@@ -234,8 +234,6 @@ namespace AvalonStudio.Languages.CPlusPlus
                     {
                         var typedText = string.Empty;
 
-                        var hint = string.Empty;
-
                         if (codeCompletion.CompletionString.Availability == AvailabilityKind.Available || codeCompletion.CompletionString.Availability == AvailabilityKind.Deprecated)
                         {
                             foreach (var chunk in codeCompletion.CompletionString.Chunks)
@@ -244,8 +242,6 @@ namespace AvalonStudio.Languages.CPlusPlus
                                 {
                                     typedText = chunk.Text;
                                 }
-
-                                hint += chunk.Text;
 
                                 switch (chunk.Kind)
                                 {
@@ -260,21 +256,15 @@ namespace AvalonStudio.Languages.CPlusPlus
                                     case CompletionChunkKind.Placeholder:
                                     case CompletionChunkKind.Comma:
                                         break;
-
-                                    default:
-                                        hint += " ";
-                                        break;
                                 }
                             }
 
                             if (filter == string.Empty || typedText.StartsWith(filter))
                             {
-                                var completion = new CodeCompletionData
+                                var completion = new CodeCompletionData (typedText, typedText)
                                 {
-                                    Suggestion = typedText,
                                     Priority = codeCompletion.CompletionString.Priority,
                                     Kind = FromClangKind(codeCompletion.CursorKind),
-                                    Hint = hint,
                                     BriefComment = codeCompletion.CompletionString.BriefComment
                                 };
 

--- a/AvalonStudio/AvalonStudio.Languages.CPlusPlus/CPlusPlusLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.CPlusPlus/CPlusPlusLanguageService.cs
@@ -5,6 +5,7 @@ using AvaloniaEdit.Indentation;
 using AvaloniaEdit.Indentation.CSharp;
 using AvaloniaEdit.Rendering;
 using AvalonStudio.CodeEditor;
+using AvalonStudio.Editor;
 using AvalonStudio.Extensibility.Editor;
 using AvalonStudio.Extensibility.Languages;
 using AvalonStudio.Extensibility.Languages.CompletionAssistance;
@@ -146,6 +147,9 @@ namespace AvalonStudio.Languages.CPlusPlus
         public string LanguageId => "cpp";
 
         public IObservable<TextSegmentCollection<Diagnostic>> Diagnostics => null;
+
+        public IEnumerable<ICodeEditorInputHelper> InputHelpers => null;
+
         private CodeCompletionKind FromClangKind(NClang.CursorKind kind)
         {
             switch (kind)

--- a/AvalonStudio/AvalonStudio.Languages.CSharp/CSharpLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.CSharp/CSharpLanguageService.cs
@@ -196,11 +196,7 @@
             {
                 foreach (var completion in data.Items)
                 {
-                    var newCompletion = new CodeCompletionData()
-                    {
-                        Suggestion = completion.FilterText,
-                        Hint = completion.DisplayText
-                    };
+                    var newCompletion = new CodeCompletionData(completion.DisplayText, completion.DisplayText);
 
                     if (completion.Properties.ContainsKey("SymbolKind"))
                     {

--- a/AvalonStudio/AvalonStudio.Languages.CSharp/CSharpLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.CSharp/CSharpLanguageService.cs
@@ -7,6 +7,7 @@
     using AvaloniaEdit.Indentation.CSharp;
     using AvaloniaEdit.Rendering;
     using AvalonStudio.CodeEditor;
+    using AvalonStudio.Editor;
     using AvalonStudio.Extensibility.Languages.CompletionAssistance;
     using AvalonStudio.Languages;
     using AvalonStudio.Projects;
@@ -59,6 +60,8 @@
                 return typeof(BlankOmniSharpProjectTemplate);
             }
         }
+
+        public IEnumerable<ICodeEditorInputHelper> InputHelpers => null;
 
         public bool CanTriggerIntellisense(char currentChar, char previousChar)
         {

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/AvalonStudio.Languages.Xaml.csproj
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/AvalonStudio.Languages.Xaml.csproj
@@ -9,6 +9,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <ProjectReference Include="..\Avalonia.Designer.HostApp\Avalonia.Designer.HostApp.csproj" />
     <ProjectReference Include="..\Avalonia.Ide\src\Avalonia.Ide.CompletionEngine.SrmMetadataProvider\Avalonia.Ide.CompletionEngine.SrmMetadataProvider.csproj" />
     <ProjectReference Include="..\Avalonia.Ide\src\Avalonia.Ide.CompletionEngine\Avalonia.Ide.CompletionEngine.csproj" />
     <ProjectReference Include="..\AvalonStudio.Controls.Standard\AvalonStudio.Controls.Standard.csproj" />

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/AvaloniaPreviewer.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/AvaloniaPreviewer.cs
@@ -182,11 +182,7 @@ namespace AvalonStudio.Languages.Xaml
         {
             base.OnTemplateApplied(e);
 
-            var scrollViewer = e.NameScope.Find<ScrollViewer>("PART_Remote");
-
-            _remoteContainer = new Center();
-
-            scrollViewer.Content = _remoteContainer;
+            _remoteContainer = e.NameScope.Find<Center>("PART_Center");
         }
 
         private void OnMessage(IAvaloniaRemoteTransportConnection transport, object obj)

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/AvaloniaPreviewer.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/AvaloniaPreviewer.cs
@@ -110,7 +110,7 @@ namespace AvalonStudio.Languages.Xaml
 
                 var projectDir = Path.GetDirectoryName(file.Project.Solution.StartupProject.Executable);
 
-                var args = $@"exec --runtimeconfig $(TargetDir)$(TargetName).runtimeconfig.json --depsfile $(TargetDir)$(TargetName).deps.json {executingDir}/HostApp/Avalonia.Designer.HostApp.dll --transport tcp-bson://127.0.0.1:{port}/ $(TargetPath)".ExpandVariables(projectVariables);
+                var args = $@"exec --runtimeconfig $(TargetDir)$(TargetName).runtimeconfig.json --depsfile $(TargetDir)$(TargetName).deps.json {executingDir}/Avalonia.Designer.HostApp.dll --transport tcp-bson://127.0.0.1:{port}/ $(TargetPath)".ExpandVariables(projectVariables);
                 _currentHost = Process.Start("dotnet", args);
             }
         }

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/AvaloniaPreviewer.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/AvaloniaPreviewer.cs
@@ -175,6 +175,7 @@ namespace AvalonStudio.Languages.Xaml
 
         protected override void OnDetachedFromVisualTree(VisualTreeAttachmentEventArgs e)
         {
+            base.OnDetachedFromVisualTree(e);
             KillHost();
         }
 

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/AvaloniaPreviewer.xaml
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/AvaloniaPreviewer.xaml
@@ -4,7 +4,21 @@
         <Setter Property="Padding" Value="0"/>
         <Setter Property="Template">
             <ControlTemplate>
-                <ScrollViewer Name="PART_Remote"/>
+                <ScrollViewer Name="PART_Remote">
+                    <ScrollViewer.Background>
+                        <VisualBrush DestinationRect="0,0,20,20" TileMode="Tile">
+                            <VisualBrush.Visual>
+                                <Canvas Width="20" Height="20"  Background="#3d3d3d">
+                                    <Rectangle Height="10" Width="10" Fill="#4d4d4d" />
+                                    <Rectangle Height="10" Width="10" Canvas.Left="10" Canvas.Top="10" Fill="#4d4d4d" />
+                                </Canvas>
+                            </VisualBrush.Visual>
+                        </VisualBrush>
+                    </ScrollViewer.Background>
+                    <Border CornerRadius="20" BorderThickness="20" Margin="40" BorderBrush="#1d1d1d">
+                        <local:Center Name="PART_Center" />
+                    </Border>
+                </ScrollViewer>
             </ControlTemplate>
         </Setter>
     </Style>

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/AvaloniaPreviewer.xaml
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/AvaloniaPreviewer.xaml
@@ -8,16 +8,14 @@
                     <ScrollViewer.Background>
                         <VisualBrush DestinationRect="0,0,20,20" TileMode="Tile">
                             <VisualBrush.Visual>
-                                <Canvas Width="20" Height="20"  Background="#3d3d3d">
-                                    <Rectangle Height="10" Width="10" Fill="#4d4d4d" />
-                                    <Rectangle Height="10" Width="10" Canvas.Left="10" Canvas.Top="10" Fill="#4d4d4d" />
+                                <Canvas Width="16" Height="16"  Background="#f0f0f0">
+                                    <Rectangle Height="8" Width="8" Fill="#f5f5f5" />
+                                    <Rectangle Height="8" Width="8" Canvas.Left="8" Canvas.Top="8" Fill="#f5f5f5" />
                                 </Canvas>
                             </VisualBrush.Visual>
                         </VisualBrush>
                     </ScrollViewer.Background>
-                    <Border CornerRadius="20" BorderThickness="20" Margin="40" BorderBrush="#1d1d1d">
-                        <local:Center Name="PART_Center" />
-                    </Border>
+                    <local:Center Name="PART_Center"  Margin="40" />
                 </ScrollViewer>
             </ControlTemplate>
         </Setter>

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/CompleteCloseTagCodeEditorHelper.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/CompleteCloseTagCodeEditorHelper.cs
@@ -1,0 +1,37 @@
+﻿using Avalonia.Ide.CompletionEngine;
+using Avalonia.Input;
+using AvalonStudio.Editor;
+using AvalonStudio.Extensibility.Documents;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AvalonStudio.Languages.Xaml
+{
+    class CompleteCloseTagCodeEditorHelper : ICodeEditorInputHelper
+    {
+        public void AfterTextInput(ILanguageService languageServivce, ITextDocument document, TextInputEventArgs args)
+        {
+            if (args.Text == ">")
+            {
+                var textBefore = document.Text.Substring(0, Math.Max(0, document.Caret - 1));
+                if (textBefore.Length > 2 && textBefore[textBefore.Length - 1] != '/')
+                {
+                    var state = XmlParser.Parse(textBefore);
+                    if (state.State == XmlParser.ParserState.InsideElement
+                        || state.State == XmlParser.ParserState.StartElement
+                        || state.State == XmlParser.ParserState.AfterAttributeValue)
+                    {
+                        var caret = document.Caret;
+                        document.Replace(caret, 0, $"</{state.TagName}>");
+                        document.Caret = caret;
+                    }
+                }
+            }
+        }
+
+        public void BeforeTextInput(ILanguageService languageService, ITextDocument document, TextInputEventArgs args)
+        {
+        }
+    }
+}

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/CompleteCloseTagCodeEditorHelper.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/CompleteCloseTagCodeEditorHelper.cs
@@ -3,8 +3,6 @@ using Avalonia.Input;
 using AvalonStudio.Editor;
 using AvalonStudio.Extensibility.Documents;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace AvalonStudio.Languages.Xaml
 {
@@ -14,7 +12,8 @@ namespace AvalonStudio.Languages.Xaml
         {
             if (args.Text == ">")
             {
-                var textBefore = editor.Document.Text.Substring(0, Math.Max(0, editor.Offset - 1));
+                var textBefore = editor.Document.GetText(0, Math.Max(0, editor.Offset - 1));
+
                 if (textBefore.Length > 2 && textBefore[textBefore.Length - 1] != '/')
                 {
                     var state = XmlParser.Parse(textBefore);

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/CompleteCloseTagCodeEditorHelper.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/CompleteCloseTagCodeEditorHelper.cs
@@ -10,11 +10,11 @@ namespace AvalonStudio.Languages.Xaml
 {
     class CompleteCloseTagCodeEditorHelper : ICodeEditorInputHelper
     {
-        public void AfterTextInput(ILanguageService languageServivce, ITextDocument document, TextInputEventArgs args)
+        public void AfterTextInput(ILanguageService languageServivce, IEditor editor, TextInputEventArgs args)
         {
             if (args.Text == ">")
             {
-                var textBefore = document.Text.Substring(0, Math.Max(0, document.Caret - 1));
+                var textBefore = editor.Document.Text.Substring(0, Math.Max(0, editor.Offset - 1));
                 if (textBefore.Length > 2 && textBefore[textBefore.Length - 1] != '/')
                 {
                     var state = XmlParser.Parse(textBefore);
@@ -22,15 +22,15 @@ namespace AvalonStudio.Languages.Xaml
                         || state.State == XmlParser.ParserState.StartElement
                         || state.State == XmlParser.ParserState.AfterAttributeValue)
                     {
-                        var caret = document.Caret;
-                        document.Replace(caret, 0, $"</{state.TagName}>");
-                        document.Caret = caret;
+                        var caret = editor.Offset;
+                        editor.Document.Replace(caret, 0, $"</{state.TagName}>");
+                        editor.Offset = caret;
                     }
                 }
             }
         }
 
-        public void BeforeTextInput(ILanguageService languageService, ITextDocument document, TextInputEventArgs args)
+        public void BeforeTextInput(ILanguageService languageService, IEditor editor, TextInputEventArgs args)
         {
         }
     }

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/InsertExtraNewLineBetweenAttributesOnEnterCodeInputHelper.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/InsertExtraNewLineBetweenAttributesOnEnterCodeInputHelper.cs
@@ -28,7 +28,7 @@ namespace AvalonStudio.Languages.Xaml
                     {
                         state = XmlParser.Parse(textBefore.Substring(0, Math.Max(0, idx)));
 
-                        if (state.State == XmlParser.ParserState.StartElement && editor.Document.Text[editor.Offset] == '<')
+                        if ((state.State == XmlParser.ParserState.StartElement || state.State == XmlParser.ParserState.AfterAttributeValue) && editor.Document.Text[editor.Offset] == '<')
                         {
                             var newline = "\n";
 

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/InsertExtraNewLineBetweenAttributesOnEnterCodeInputHelper.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/InsertExtraNewLineBetweenAttributesOnEnterCodeInputHelper.cs
@@ -1,0 +1,50 @@
+﻿using Avalonia.Ide.CompletionEngine;
+using Avalonia.Input;
+using AvalonStudio.Editor;
+using AvalonStudio.Extensibility.Documents;
+using System;
+
+namespace AvalonStudio.Languages.Xaml
+{
+    class InsertExtraNewLineBetweenAttributesOnEnterCodeInputHelper : ICodeEditorInputHelper
+    {
+        public void AfterTextInput(ILanguageService languageServivce, IEditor editor, TextInputEventArgs args)
+        {
+
+        }
+
+        public void BeforeTextInput(ILanguageService languageService, IEditor editor, TextInputEventArgs args)
+        {
+              if (args.Text == "\n")
+            {
+                //Check if we are not inside a tag
+                var textBefore = editor.Document.Text.Substring(0, Math.Max(0, editor.Offset));
+                var state = XmlParser.Parse(textBefore);
+                if (state.State == XmlParser.ParserState.None)
+                {
+                    //Find latest tag end
+                    var idx = textBefore.LastIndexOf('>');
+                    if (idx != -1)
+                    {
+                        state = XmlParser.Parse(textBefore.Substring(0, Math.Max(0, idx)));
+
+                        if (state.State == XmlParser.ParserState.StartElement && editor.Document.Text[editor.Offset] == '<')
+                        {
+                            var newline = "\n";
+
+                            editor.Document.TrimTrailingWhiteSpace(editor.Line);
+
+                            editor.Document.Insert(editor.Offset, newline);
+
+                            editor.Document.TrimTrailingWhiteSpace(editor.Line - 1);
+
+                            editor.Offset -= newline.Length;
+
+                            editor.IndentLine(editor.Line);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/InsertExtraNewLineBetweenAttributesOnEnterCodeInputHelper.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/InsertExtraNewLineBetweenAttributesOnEnterCodeInputHelper.cs
@@ -15,18 +15,20 @@ namespace AvalonStudio.Languages.Xaml
 
         public void BeforeTextInput(ILanguageService languageService, IEditor editor, TextInputEventArgs args)
         {
-              if (args.Text == "\n")
+            if (args.Text == "\n")
             {
                 //Check if we are not inside a tag
-                var textBefore = editor.Document.Text.Substring(0, Math.Max(0, editor.Offset));
+                var textBefore = editor.Document.GetText(0, Math.Max(0, editor.Offset));
+
                 var state = XmlParser.Parse(textBefore);
                 if (state.State == XmlParser.ParserState.None)
                 {
                     //Find latest tag end
                     var idx = textBefore.LastIndexOf('>');
+
                     if (idx != -1)
                     {
-                        state = XmlParser.Parse(textBefore.Substring(0, Math.Max(0, idx)));
+                        state = XmlParser.Parse(editor.Document.GetText(0, Math.Max(0, idx)));
 
                         if ((state.State == XmlParser.ParserState.StartElement || state.State == XmlParser.ParserState.AfterAttributeValue) && editor.Document.Text[editor.Offset] == '<')
                         {

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/InsertQuotesForPropertyValueCodeEditorHelper.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/InsertQuotesForPropertyValueCodeEditorHelper.cs
@@ -1,0 +1,33 @@
+﻿using Avalonia.Ide.CompletionEngine;
+using Avalonia.Input;
+using AvalonStudio.Editor;
+using AvalonStudio.Extensibility.Documents;
+using System;
+
+namespace AvalonStudio.Languages.Xaml
+{
+    class InsertQuotesForPropertyValueCodeEditorHelper : ICodeEditorInputHelper
+    {
+        public void AfterTextInput(ILanguageService languageServivce, ITextDocument document, TextInputEventArgs args)
+        {
+            if (args.Text == "=")
+            {
+                var textBefore = document.Text.Substring(0, Math.Max(0, document.Caret - 1));
+                if (textBefore.Length > 2 && textBefore[textBefore.Length - 1] != '/')
+                {
+                    var state = XmlParser.Parse(textBefore);
+                    if (state.State == XmlParser.ParserState.StartAttribute)
+                    {
+                        var caret = document.Caret;
+                        document.Replace(caret, 0, "\"\" ");
+                        document.Caret = caret + 1;
+                    }
+                }
+            }
+        }
+
+        public void BeforeTextInput(ILanguageService languageService, ITextDocument document, TextInputEventArgs args)
+        {
+        }
+    }
+}

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/InsertQuotesForPropertyValueCodeEditorHelper.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/InsertQuotesForPropertyValueCodeEditorHelper.cs
@@ -8,25 +8,25 @@ namespace AvalonStudio.Languages.Xaml
 {
     class InsertQuotesForPropertyValueCodeEditorHelper : ICodeEditorInputHelper
     {
-        public void AfterTextInput(ILanguageService languageServivce, ITextDocument document, TextInputEventArgs args)
+        public void AfterTextInput(ILanguageService languageServivce, IEditor editor, TextInputEventArgs args)
         {
             if (args.Text == "=")
             {
-                var textBefore = document.Text.Substring(0, Math.Max(0, document.Caret - 1));
+                var textBefore = editor.Document.Text.Substring(0, Math.Max(0, editor.Offset - 1));
                 if (textBefore.Length > 2 && textBefore[textBefore.Length - 1] != '/')
                 {
                     var state = XmlParser.Parse(textBefore);
                     if (state.State == XmlParser.ParserState.StartAttribute)
                     {
-                        var caret = document.Caret;
-                        document.Replace(caret, 0, "\"\" ");
-                        document.Caret = caret + 1;
+                        var caret = editor.Offset;
+                        editor.Document.Replace(caret, 0, "\"\" ");
+                        editor.Offset = caret + 1;
                     }
                 }
             }
         }
 
-        public void BeforeTextInput(ILanguageService languageService, ITextDocument document, TextInputEventArgs args)
+        public void BeforeTextInput(ILanguageService languageService, IEditor editor, TextInputEventArgs args)
         {
         }
     }

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/InsertQuotesForPropertyValueCodeEditorHelper.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/InsertQuotesForPropertyValueCodeEditorHelper.cs
@@ -12,14 +12,15 @@ namespace AvalonStudio.Languages.Xaml
         {
             if (args.Text == "=")
             {
-                var textBefore = editor.Document.Text.Substring(0, Math.Max(0, editor.Offset - 1));
+                var textBefore = editor.Document.GetText(0, Math.Max(0, editor.Offset - 1));
+
                 if (textBefore.Length > 2 && textBefore[textBefore.Length - 1] != '/')
                 {
                     var state = XmlParser.Parse(textBefore);
                     if (state.State == XmlParser.ParserState.StartAttribute)
                     {
                         var caret = editor.Offset;
-                        editor.Document.Replace(caret, 0, "\"\" ");
+                        editor.Document.Replace(caret, 0, "\"\"");
                         editor.Offset = caret + 1;
                     }
                 }

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/TerminateElementCodeEditorHelper.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/TerminateElementCodeEditorHelper.cs
@@ -3,8 +3,6 @@ using Avalonia.Input;
 using AvalonStudio.Editor;
 using AvalonStudio.Extensibility.Documents;
 using System;
-using System.Collections.Generic;
-using System.Text;
 
 namespace AvalonStudio.Languages.Xaml
 {
@@ -14,7 +12,8 @@ namespace AvalonStudio.Languages.Xaml
         {
             if (args.Text == "/")
             {
-                var textBefore = editor.Document.Text.Substring(0, Math.Max(0, editor.Offset - 1));
+                var textBefore = editor.Document.GetText(0, Math.Max(0, editor.Offset - 1));
+
                 if (textBefore.Length > 2 && textBefore[textBefore.Length - 1] != '/')
                 {
                     var state = XmlParser.Parse(textBefore);

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/TerminateElementCodeEditorHelper.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/TerminateElementCodeEditorHelper.cs
@@ -1,0 +1,114 @@
+﻿using Avalonia.Ide.CompletionEngine;
+using Avalonia.Input;
+using AvalonStudio.Editor;
+using AvalonStudio.Extensibility.Documents;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AvalonStudio.Languages.Xaml
+{
+    class TerminateElementCodeEditorHelper : ICodeEditorInputHelper
+    {
+        public void AfterTextInput(ILanguageService languageServivce, ITextDocument document, TextInputEventArgs args)
+        {
+            if (args.Text == "/")
+            {
+                var textBefore = document.Text.Substring(0, Math.Max(0, document.Caret - 1));
+                if (textBefore.Length > 2 && textBefore[textBefore.Length - 1] != '/')
+                {
+                    var state = XmlParser.Parse(textBefore);
+                    if (state.State == XmlParser.ParserState.InsideElement
+                        || state.State == XmlParser.ParserState.StartElement
+                        || state.State == XmlParser.ParserState.AfterAttributeValue)
+                    {
+                        var caret = document.Caret;
+                        document.Replace(caret, 0, $">");
+                        document.Caret = caret + 1;
+                    }
+                }
+            }
+        }
+
+        public void BeforeTextInput(ILanguageService languageService, ITextDocument document, TextInputEventArgs args)
+        {            
+        }
+    }
+
+    class InsertQuotesForPropertyValueCodeEditorHelper : ICodeEditorInputHelper
+    {
+        public void AfterTextInput(ILanguageService languageServivce, ITextDocument document, TextInputEventArgs args)
+        {
+            if (args.Text == "=")
+            {
+                var textBefore = document.Text.Substring(0, Math.Max(0, document.Caret - 1));
+                if (textBefore.Length > 2 && textBefore[textBefore.Length - 1] != '/')
+                {
+                    var state = XmlParser.Parse(textBefore);
+                    if (state.State == XmlParser.ParserState.StartAttribute)
+                    {
+                        var caret = document.Caret;
+                        document.Replace(caret, 0, "\"\" ");
+                        document.Caret = caret + 1;
+                    }
+                }
+            }
+        }
+
+        public void BeforeTextInput(ILanguageService languageService, ITextDocument document, TextInputEventArgs args)
+        {
+        }
+    }
+
+    class XamlIndentationCodeEditorHelper : ICodeEditorInputHelper
+    {
+        public void AfterTextInput(ILanguageService languageServivce, ITextDocument document, TextInputEventArgs args)
+        {
+            if (args.Text == "\n")
+            {
+                //Check if we are not inside a tag
+                var textBefore = document.Text.Substring(0, Math.Max(0, document.Caret - 1));
+                var state = XmlParser.Parse(textBefore);
+                if (state.State == XmlParser.ParserState.None)
+                {
+                    //Find latest tag end
+                    var idx = textBefore.LastIndexOf('>');
+                    if (idx != -1)
+                    {
+                        state = XmlParser.Parse(textBefore.Substring(0, Math.Max(0, idx - 1)));
+                        if (state.TagName.StartsWith('/'))
+                        {
+                            //TODO: find matching starting tag. XmlParser can't do that right now.
+                            return;
+                        }
+                        //Find starting '<'
+                        bool insideAttribute = false;
+                        for (; idx >= 0; idx--)
+                        {
+                            var ch = textBefore[idx];
+                            if (ch == '"')
+                                insideAttribute = !insideAttribute;
+                            if (ch == '<' && !insideAttribute)
+                            {
+                                var textBeforeTag = textBefore.Substring(0, idx);
+                                var lineStartIdx = textBeforeTag.LastIndexOf('\n');
+                                if (lineStartIdx != -1)
+                                {
+                                    //TODO: Do something about '\t' characters
+                                    var prefixLength = (idx - lineStartIdx) - 1;
+                                    document.Replace(document.Caret, 0,
+                                        new string(' ', prefixLength));
+                                }
+                                return;
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        public void BeforeTextInput(ILanguageService languageService, ITextDocument document, TextInputEventArgs args)
+        {
+        }
+    }
+}

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/TerminateElementCodeEditorHelper.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/TerminateElementCodeEditorHelper.cs
@@ -35,39 +35,19 @@ namespace AvalonStudio.Languages.Xaml
         }
     }
 
-    class InsertQuotesForPropertyValueCodeEditorHelper : ICodeEditorInputHelper
-    {
-        public void AfterTextInput(ILanguageService languageServivce, ITextDocument document, TextInputEventArgs args)
-        {
-            if (args.Text == "=")
-            {
-                var textBefore = document.Text.Substring(0, Math.Max(0, document.Caret - 1));
-                if (textBefore.Length > 2 && textBefore[textBefore.Length - 1] != '/')
-                {
-                    var state = XmlParser.Parse(textBefore);
-                    if (state.State == XmlParser.ParserState.StartAttribute)
-                    {
-                        var caret = document.Caret;
-                        document.Replace(caret, 0, "\"\" ");
-                        document.Caret = caret + 1;
-                    }
-                }
-            }
-        }
-
-        public void BeforeTextInput(ILanguageService languageService, ITextDocument document, TextInputEventArgs args)
-        {
-        }
-    }
-
     class XamlIndentationCodeEditorHelper : ICodeEditorInputHelper
     {
         public void AfterTextInput(ILanguageService languageServivce, ITextDocument document, TextInputEventArgs args)
         {
+            
+        }
+
+        public void BeforeTextInput(ILanguageService languageService, ITextDocument document, TextInputEventArgs args)
+        {
             if (args.Text == "\n")
             {
                 //Check if we are not inside a tag
-                var textBefore = document.Text.Substring(0, Math.Max(0, document.Caret - 1));
+                var textBefore = document.Text.Substring(0, Math.Max(0, document.Caret));
                 var state = XmlParser.Parse(textBefore);
                 if (state.State == XmlParser.ParserState.None)
                 {
@@ -75,40 +55,15 @@ namespace AvalonStudio.Languages.Xaml
                     var idx = textBefore.LastIndexOf('>');
                     if (idx != -1)
                     {
-                        state = XmlParser.Parse(textBefore.Substring(0, Math.Max(0, idx - 1)));
-                        if (state.TagName.StartsWith('/'))
+                        state = XmlParser.Parse(textBefore.Substring(0, Math.Max(0, idx)));
+
+                        if(state.State == XmlParser.ParserState.StartElement && document.Text[document.Caret] == '<')
                         {
-                            //TODO: find matching starting tag. XmlParser can't do that right now.
-                            return;
-                        }
-                        //Find starting '<'
-                        bool insideAttribute = false;
-                        for (; idx >= 0; idx--)
-                        {
-                            var ch = textBefore[idx];
-                            if (ch == '"')
-                                insideAttribute = !insideAttribute;
-                            if (ch == '<' && !insideAttribute)
-                            {
-                                var textBeforeTag = textBefore.Substring(0, idx);
-                                var lineStartIdx = textBeforeTag.LastIndexOf('\n');
-                                if (lineStartIdx != -1)
-                                {
-                                    //TODO: Do something about '\t' characters
-                                    var prefixLength = (idx - lineStartIdx) - 1;
-                                    document.Replace(document.Caret, 0,
-                                        new string(' ', prefixLength));
-                                }
-                                return;
-                            }
+                            document.Replace(document.Caret, 0, "\n");
                         }
                     }
                 }
             }
-        }
-
-        public void BeforeTextInput(ILanguageService languageService, ITextDocument document, TextInputEventArgs args)
-        {
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/TerminateElementCodeEditorHelper.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/TerminateElementCodeEditorHelper.cs
@@ -10,11 +10,11 @@ namespace AvalonStudio.Languages.Xaml
 {
     class TerminateElementCodeEditorHelper : ICodeEditorInputHelper
     {
-        public void AfterTextInput(ILanguageService languageServivce, ITextDocument document, TextInputEventArgs args)
+        public void AfterTextInput(ILanguageService languageServivce, IEditor editor, TextInputEventArgs args)
         {
             if (args.Text == "/")
             {
-                var textBefore = document.Text.Substring(0, Math.Max(0, document.Caret - 1));
+                var textBefore = editor.Document.Text.Substring(0, Math.Max(0, editor.Offset - 1));
                 if (textBefore.Length > 2 && textBefore[textBefore.Length - 1] != '/')
                 {
                     var state = XmlParser.Parse(textBefore);
@@ -22,48 +22,16 @@ namespace AvalonStudio.Languages.Xaml
                         || state.State == XmlParser.ParserState.StartElement
                         || state.State == XmlParser.ParserState.AfterAttributeValue)
                     {
-                        var caret = document.Caret;
-                        document.Replace(caret, 0, $">");
-                        document.Caret = caret + 1;
+                        var caret = editor.Offset;
+                        editor.Document.Replace(caret, 0, $">");
+                        editor.Offset = caret + 1;
                     }
                 }
             }
         }
 
-        public void BeforeTextInput(ILanguageService languageService, ITextDocument document, TextInputEventArgs args)
-        {            
-        }
-    }
-
-    class XamlIndentationCodeEditorHelper : ICodeEditorInputHelper
-    {
-        public void AfterTextInput(ILanguageService languageServivce, ITextDocument document, TextInputEventArgs args)
+        public void BeforeTextInput(ILanguageService languageService, IEditor editor, TextInputEventArgs args)
         {
-            
-        }
-
-        public void BeforeTextInput(ILanguageService languageService, ITextDocument document, TextInputEventArgs args)
-        {
-            if (args.Text == "\n")
-            {
-                //Check if we are not inside a tag
-                var textBefore = document.Text.Substring(0, Math.Max(0, document.Caret));
-                var state = XmlParser.Parse(textBefore);
-                if (state.State == XmlParser.ParserState.None)
-                {
-                    //Find latest tag end
-                    var idx = textBefore.LastIndexOf('>');
-                    if (idx != -1)
-                    {
-                        state = XmlParser.Parse(textBefore.Substring(0, Math.Max(0, idx)));
-
-                        if(state.State == XmlParser.ParserState.StartElement && document.Text[document.Caret] == '<')
-                        {
-                            document.Replace(document.Caret, 0, "\n");
-                        }
-                    }
-                }
-            }
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml
@@ -17,7 +17,7 @@
                                    
                                    FontFamily="{Binding FontFamily}" 
                                    FontSize="{Binding VisualFontSize}"
-                                  
+                                  HighlightSelectedWord="False"
                                   SourceFile="{Binding SourceFile}" 
                                   IsDirty="{Binding IsDirty}"
                                   SourceText="{Binding SourceText}">

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml
@@ -1,7 +1,7 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:previewer="clr-namespace:AvalonStudio.Languages.Xaml"
              xmlns:as="clr-namespace:AvalonStudio.Extensibility.Controls;assembly=AvalonStudio.Extensibility"
-             xmlns:editor="clr-namespace:AvalonStudio.Controls.Standard.CodeEditor;assembly=AvalonStudio.Controls.Standard">
+             xmlns:local="clr-namespace:AvalonStudio.Extensibility.Editor;assembly=AvalonStudio.Extensibility">
     <Grid RowDefinitions="*,5,*">
         <Grid DockPanel.Dock="Top" Background="{DynamicResource ThemeEditorBackground}">
             <Border BorderBrush="{DynamicResource ThemeBorderDarkBrush}" BorderThickness="1">
@@ -11,6 +11,6 @@
 
         <GridSplitter Grid.Row="1" />
 
-        <ContentPresenter Grid.Row="2"  Content="{Binding CodeEditor}" />
+        <local:EditorView Grid.Row="2"  DataContext="{Binding CodeEditor}" />
     </Grid>
 </UserControl>

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml
@@ -20,7 +20,7 @@
                                   HighlightSelectedWord="False"
                                   SourceFile="{Binding SourceFile}" 
                                   IsDirty="{Binding IsDirty}"
-                                  SourceText="{Binding SourceText}">
+                                  SourceText="{Binding SourceText}" DocumentAccessor="{Binding DocumentAccessor}">
             </editor:CodeEditor>
         </Grid>
     </Border>

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml
@@ -1,27 +1,16 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:previewer="clr-namespace:AvalonStudio.Languages.Xaml"
-             xmlns:editor="clr-namespace:AvalonStudio.Controls.Standard.CodeEditor;assembly=AvalonStudio.Controls.Standard"
-             >
-    <Border BorderBrush="{DynamicResource ThemeBorderDarkBrush}" BorderThickness="1">
-        <Grid RowDefinitions="*,10,*">
-            <Grid DockPanel.Dock="Top" Background="{DynamicResource ThemeEditorBackground}">
-                <previewer:AvaloniaPreviewer Xaml="{Binding SourceText}" SourceFile="{Binding SourceFile}" />
-            </Grid>
-
-            <GridSplitter Grid.Row="1" Height="4" />
-
-            <editor:CodeEditor Grid.Row="2" Name="editor"
-                                   BorderThickness="0" Margin="0"
-                                   VerticalAlignment="Stretch"
-                                   Background="{DynamicResource ThemeEditorBackground}"
-                                   
-                                   FontFamily="{Binding FontFamily}" 
-                                   FontSize="{Binding VisualFontSize}"
-                                  HighlightSelectedWord="False"
-                                  SourceFile="{Binding SourceFile}" 
-                                  IsDirty="{Binding IsDirty}"
-                                  SourceText="{Binding SourceText}" DocumentAccessor="{Binding DocumentAccessor}">
-            </editor:CodeEditor>
+             xmlns:as="clr-namespace:AvalonStudio.Extensibility.Controls;assembly=AvalonStudio.Extensibility"
+             xmlns:editor="clr-namespace:AvalonStudio.Controls.Standard.CodeEditor;assembly=AvalonStudio.Controls.Standard">
+    <Grid RowDefinitions="*,5,*">
+        <Grid DockPanel.Dock="Top" Background="{DynamicResource ThemeEditorBackground}">
+            <Border BorderBrush="{DynamicResource ThemeBorderDarkBrush}" BorderThickness="1">
+                <previewer:AvaloniaPreviewer Xaml="{Binding CodeEditor.SourceText}" SourceFile="{Binding SourceFile}" />
+            </Border>
         </Grid>
-    </Border>
+
+        <GridSplitter Grid.Row="1" />
+
+        <ContentPresenter Grid.Row="2"  Content="{Binding CodeEditor}" />
+    </Grid>
 </UserControl>

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml.cs
@@ -1,4 +1,7 @@
+using System;
 using Avalonia.Controls;
+using Avalonia.Ide.CompletionEngine;
+using Avalonia.Input;
 using Avalonia.Markup.Xaml;
 using AvaloniaEdit.Highlighting;
 
@@ -6,13 +9,78 @@ namespace AvalonStudio.Languages.Xaml
 {
     public class XamlEditorView : UserControl
     {
+        private AvaloniaEdit.TextEditor _editor;
         public XamlEditorView()
         {
             InitializeComponent();
-            var editor = this.FindControl<AvaloniaEdit.TextEditor>("editor");
-            editor.SyntaxHighlighting = HighlightingManager.Instance.GetDefinition("XML");
+            _editor = this.FindControl<AvaloniaEdit.TextEditor>("editor");
+            _editor.SyntaxHighlighting = HighlightingManager.Instance.GetDefinition("XML");
+            _editor.TextArea.TextEntered += OnTextEntered;
         }
 
+        void OnTextEntered(object sender, TextInputEventArgs args)
+        {
+            if (args.Text == ">")
+            {
+                var textBefore = _editor.Text.Substring(0, Math.Max(0, _editor.TextArea.Caret.Offset - 1));
+                if (textBefore.Length>2 && textBefore[textBefore.Length - 1] != '/')
+                {
+                    var state = XmlParser.Parse(textBefore);
+                    if (state.State == XmlParser.ParserState.InsideElement
+                        || state.State == XmlParser.ParserState.StartElement 
+                        || state.State == XmlParser.ParserState.AfterAttributeValue)
+                    {
+                        var caret = _editor.TextArea.Caret.Offset;
+                        _editor.Document.Replace(_editor.TextArea.Caret.Offset, 0, $"</{state.TagName}>");
+                        _editor.TextArea.Caret.Offset = caret;
+                    }
+                }
+            }
+            if (args.Text == "\n")
+            {
+                //Check if we are not inside a tag
+                var textBefore = _editor.Text.Substring(0, Math.Max(0, _editor.TextArea.Caret.Offset - 1));
+                var state = XmlParser.Parse(textBefore);
+                if (state.State == XmlParser.ParserState.None)
+                {
+                    //Find latest tag end
+                    var idx = textBefore.LastIndexOf('>');
+                    if (idx != -1)
+                    {
+                        state = XmlParser.Parse(textBefore.Substring(0, Math.Max(0, idx - 1)));
+                        if (state.TagName.StartsWith('/'))
+                        {
+                            //TODO: find matching starting tag. XmlParser can't do that right now.
+                            return;
+                        }
+                        //Find starting '<'
+                        bool insideAttribute = false;
+                        for(;idx>=0; idx--)
+                        {
+                            var ch = textBefore[idx];
+                            if (ch == '"')
+                                insideAttribute = !insideAttribute;
+                            if (ch == '<' && !insideAttribute)
+                            {
+                                var textBeforeTag = textBefore.Substring(0, idx);
+                                var lineStartIdx = textBeforeTag.LastIndexOf('\n');
+                                if (lineStartIdx != -1)
+                                {
+                                    //TODO: Do something about '\t' characters
+                                    var prefixLength = idx - lineStartIdx;
+                                    _editor.Document.Replace(_editor.TextArea.Caret.Offset, 0,
+                                        new string(' ', prefixLength));
+                                }
+                                return;
+                            }
+
+
+                        }
+                    }
+                }
+            }
+        }
+        
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml.cs
@@ -9,111 +9,11 @@ namespace AvalonStudio.Languages.Xaml
 {
     public class XamlEditorView : UserControl
     {
-        private AvaloniaEdit.TextEditor _editor;
         public XamlEditorView()
         {
             InitializeComponent();
-            _editor = this.FindControl<AvaloniaEdit.TextEditor>("editor");
-            _editor.SyntaxHighlighting = HighlightingManager.Instance.GetDefinition("XML");
-            _editor.TextArea.TextEntered += OnTextEntered;
         }
 
-        void OnTextEntered(object sender, TextInputEventArgs args)
-        {
-            if (args.Text == ">")
-            {
-                var textBefore = _editor.Text.Substring(0, Math.Max(0, _editor.TextArea.Caret.Offset - 1));
-                if (textBefore.Length>2 && textBefore[textBefore.Length - 1] != '/')
-                {
-                    var state = XmlParser.Parse(textBefore);
-                    if (state.State == XmlParser.ParserState.InsideElement
-                        || state.State == XmlParser.ParserState.StartElement 
-                        || state.State == XmlParser.ParserState.AfterAttributeValue)
-                    {
-                        var caret = _editor.TextArea.Caret.Offset;
-                        _editor.Document.Replace(_editor.TextArea.Caret.Offset, 0, $"</{state.TagName}>");
-                        _editor.TextArea.Caret.Offset = caret;
-                    }
-                }
-            }
-
-            if (args.Text == "/")
-            {
-                var textBefore = _editor.Text.Substring(0, Math.Max(0, _editor.TextArea.Caret.Offset - 1));
-                if (textBefore.Length > 2 && textBefore[textBefore.Length - 1] != '/')
-                {
-                    var state = XmlParser.Parse(textBefore);
-                    if (state.State == XmlParser.ParserState.InsideElement
-                        || state.State == XmlParser.ParserState.StartElement
-                        || state.State == XmlParser.ParserState.AfterAttributeValue)
-                    {
-                        var caret = _editor.TextArea.Caret.Offset;
-                        _editor.Document.Replace(_editor.TextArea.Caret.Offset, 0, $">");
-                        _editor.TextArea.Caret.Offset = caret + 1;
-                    }
-                }
-            }
-
-            if (args.Text == "=")
-            {
-                var textBefore = _editor.Text.Substring(0, Math.Max(0, _editor.TextArea.Caret.Offset - 1));
-                if (textBefore.Length > 2 && textBefore[textBefore.Length - 1] != '/')
-                {
-                    var state = XmlParser.Parse(textBefore);
-                    if (state.State == XmlParser.ParserState.StartAttribute)
-                    {
-                        var caret = _editor.TextArea.Caret.Offset;
-                        _editor.Document.Replace(_editor.TextArea.Caret.Offset, 0, "\"\" ");
-                        _editor.TextArea.Caret.Offset = caret+1;
-                    }
-                }
-            }
-
-            if (args.Text == "\n")
-            {
-                //Check if we are not inside a tag
-                var textBefore = _editor.Text.Substring(0, Math.Max(0, _editor.TextArea.Caret.Offset - 1));
-                var state = XmlParser.Parse(textBefore);
-                if (state.State == XmlParser.ParserState.None)
-                {
-                    //Find latest tag end
-                    var idx = textBefore.LastIndexOf('>');
-                    if (idx != -1)
-                    {
-                        state = XmlParser.Parse(textBefore.Substring(0, Math.Max(0, idx - 1)));
-                        if (state.TagName.StartsWith('/'))
-                        {
-                            //TODO: find matching starting tag. XmlParser can't do that right now.
-                            return;
-                        }
-                        //Find starting '<'
-                        bool insideAttribute = false;
-                        for(;idx>=0; idx--)
-                        {
-                            var ch = textBefore[idx];
-                            if (ch == '"')
-                                insideAttribute = !insideAttribute;
-                            if (ch == '<' && !insideAttribute)
-                            {
-                                var textBeforeTag = textBefore.Substring(0, idx);
-                                var lineStartIdx = textBeforeTag.LastIndexOf('\n');
-                                if (lineStartIdx != -1)
-                                {
-                                    //TODO: Do something about '\t' characters
-                                    var prefixLength = (idx - lineStartIdx) - 1;
-                                    _editor.Document.Replace(_editor.TextArea.Caret.Offset, 0,
-                                        new string(' ', prefixLength));
-                                }
-                                return;
-                            }
-
-
-                        }
-                    }
-                }
-            }
-        }
-        
         private void InitializeComponent()
         {
             AvaloniaXamlLoader.Load(this);

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml.cs
@@ -1,5 +1,6 @@
 using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
+using AvaloniaEdit.Highlighting;
 
 namespace AvalonStudio.Languages.Xaml
 {
@@ -8,6 +9,8 @@ namespace AvalonStudio.Languages.Xaml
         public XamlEditorView()
         {
             InitializeComponent();
+            var editor = this.FindControl<AvaloniaEdit.TextEditor>("editor");
+            editor.SyntaxHighlighting = HighlightingManager.Instance.GetDefinition("XML");
         }
 
         private void InitializeComponent()

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml.cs
@@ -67,7 +67,7 @@ namespace AvalonStudio.Languages.Xaml
                                 if (lineStartIdx != -1)
                                 {
                                     //TODO: Do something about '\t' characters
-                                    var prefixLength = idx - lineStartIdx;
+                                    var prefixLength = (idx - lineStartIdx) - 1;
                                     _editor.Document.Replace(_editor.TextArea.Caret.Offset, 0,
                                         new string(' ', prefixLength));
                                 }

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorView.xaml.cs
@@ -36,6 +36,39 @@ namespace AvalonStudio.Languages.Xaml
                     }
                 }
             }
+
+            if (args.Text == "/")
+            {
+                var textBefore = _editor.Text.Substring(0, Math.Max(0, _editor.TextArea.Caret.Offset - 1));
+                if (textBefore.Length > 2 && textBefore[textBefore.Length - 1] != '/')
+                {
+                    var state = XmlParser.Parse(textBefore);
+                    if (state.State == XmlParser.ParserState.InsideElement
+                        || state.State == XmlParser.ParserState.StartElement
+                        || state.State == XmlParser.ParserState.AfterAttributeValue)
+                    {
+                        var caret = _editor.TextArea.Caret.Offset;
+                        _editor.Document.Replace(_editor.TextArea.Caret.Offset, 0, $">");
+                        _editor.TextArea.Caret.Offset = caret + 1;
+                    }
+                }
+            }
+
+            if (args.Text == "=")
+            {
+                var textBefore = _editor.Text.Substring(0, Math.Max(0, _editor.TextArea.Caret.Offset - 1));
+                if (textBefore.Length > 2 && textBefore[textBefore.Length - 1] != '/')
+                {
+                    var state = XmlParser.Parse(textBefore);
+                    if (state.State == XmlParser.ParserState.StartAttribute)
+                    {
+                        var caret = _editor.TextArea.Caret.Offset;
+                        _editor.Document.Replace(_editor.TextArea.Caret.Offset, 0, "\"\" ");
+                        _editor.TextArea.Caret.Offset = caret+1;
+                    }
+                }
+            }
+
             if (args.Text == "\n")
             {
                 //Check if we are not inside a tag

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorViewModel.cs
@@ -1,7 +1,9 @@
 ﻿using Avalonia.Controls;
 using AvalonStudio.Controls;
+using AvalonStudio.Extensibility;
 using AvalonStudio.Extensibility.Editor;
 using AvalonStudio.Projects;
+using AvalonStudio.Shell;
 using ReactiveUI;
 using System;
 using System.Collections.Generic;
@@ -9,10 +11,43 @@ using System.Text;
 
 namespace AvalonStudio.Languages.Xaml
 {
-    public class XamlEditorViewModel : TextEditorViewModel
+    public class XamlEditorViewModel : ReactiveObject, IFileDocumentTabViewModel
     {
-        public XamlEditorViewModel(ISourceFile file) : base(file)
+        private TextEditorViewModel _textEditor;
+
+        public XamlEditorViewModel(ISourceFile file)
         {
+            _textEditor = new TextEditorViewModel(file);
+            
+
+        }
+
+        public string SouceText => _textEditor.SourceText;
+
+        public TextEditorViewModel CodeEditor => _textEditor;
+
+        public ISourceFile SourceFile => ((IFileDocumentTabViewModel)_textEditor).SourceFile;
+
+        public bool IsDirty
+        {
+            get => ((IFileDocumentTabViewModel)_textEditor).IsDirty;
+            set
+            {
+                ((IFileDocumentTabViewModel)_textEditor).IsDirty = value;
+                this.RaisePropertyChanged();
+            }
+        }
+
+        public string Title { get => ((IFileDocumentTabViewModel)_textEditor).Title; set => ((IFileDocumentTabViewModel)_textEditor).Title = value; }        
+
+        public void Close()
+        {
+            IoC.Get<IShell>().RemoveDocument(this);
+        }
+
+        public void Save()
+        {
+            ((IFileDocumentTabViewModel)_textEditor).Save();
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlIndentationStrategy.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlIndentationStrategy.cs
@@ -1,0 +1,59 @@
+﻿using Avalonia.Ide.CompletionEngine;
+using AvaloniaEdit.Document;
+using AvaloniaEdit.Indentation;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace AvalonStudio.Languages.Xaml
+{
+    class XamlIndentationStrategy : DefaultIndentationStrategy
+    {
+        public override void IndentLine(TextDocument document, DocumentLine line)
+        {
+            //Check if we are not inside a tag
+            var textBefore = document.Text.Substring(0, Math.Max(0, line.EndOffset));
+            var state = XmlParser.Parse(textBefore);
+            if (state.State == XmlParser.ParserState.None)
+            {
+                //Find latest tag end
+                var idx = textBefore.LastIndexOf('>');
+                if (idx != -1)
+                {
+                    state = XmlParser.Parse(textBefore.Substring(0, Math.Max(0, idx)));
+                    if (state.TagName.StartsWith('/'))
+                    {
+                        //TODO: find matching starting tag. XmlParser can't do that right now.
+                        base.IndentLine(document, line);
+                        return;
+                    }
+                    //Find starting '<'
+                    bool insideAttribute = false;
+                    for (; idx >= 0; idx--)
+                    {
+                        var ch = textBefore[idx];
+                        if (ch == '"')
+                            insideAttribute = !insideAttribute;
+                        if (ch == '<' && !insideAttribute)
+                        {
+                            var textBeforeTag = textBefore.Substring(0, idx);
+                            var lineStartIdx = textBeforeTag.LastIndexOf('\n');
+                            if (lineStartIdx != -1)
+                            {
+                                //TODO: Do something about '\t' characters
+                                var prefixLength = (idx - lineStartIdx) + 1;
+                                document.Replace(line.EndOffset, 0,
+                                    new string(' ', prefixLength));
+                            }
+                            return;
+                        }
+                    }
+                }
+            }
+            else
+            {
+                base.IndentLine(document, line);
+            }
+        }
+    }
+}

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlIndentationStrategy.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlIndentationStrategy.cs
@@ -29,19 +29,33 @@ namespace AvalonStudio.Languages.Xaml
                     }
                     //Find starting '<'
                     bool insideAttribute = false;
+                    bool attributeTerminatorDetected = false;
+
                     for (; idx >= 0; idx--)
                     {
                         var ch = textBefore[idx];
                         if (ch == '"')
                             insideAttribute = !insideAttribute;
+
+                        if (ch == '/' && textBefore[idx + 1] == '>')
+                        {
+                            attributeTerminatorDetected = true;
+                        }
+
                         if (ch == '<' && !insideAttribute)
                         {
                             var textBeforeTag = textBefore.Substring(0, idx);
                             var lineStartIdx = textBeforeTag.LastIndexOf('\n');
-                            if (lineStartIdx != -1)
+                            if (lineStartIdx != -1 || textBeforeTag == "")
                             {
                                 //TODO: Do something about '\t' characters
                                 var prefixLength = (idx - lineStartIdx) + 1;
+
+                                if (attributeTerminatorDetected)
+                                {
+                                    prefixLength -= 2;
+                                }
+
                                 document.Replace(line.EndOffset, 0,
                                     new string(' ', prefixLength));
                             }

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlLanguageService.cs
@@ -77,7 +77,7 @@ namespace AvalonStudio.Languages.Xaml
         {
             bool result = false;
 
-            if(currentChar == '<' || currentChar == ' ')
+            if (currentChar == '<' || currentChar == ' ')
             {
                 return true;
             }
@@ -100,7 +100,11 @@ namespace AvalonStudio.Languages.Xaml
                 {
                     foreach (var completion in completionSet.Completions)
                     {
-                        results.Completions.Add(new CodeCompletionData { Suggestion = completion.DisplayText, BriefComment = completion.Description, Kind = CodeCompletionKind.PropertyPublic });
+                        results.Completions.Add(new CodeCompletionData(completion.DisplayText, completion.InsertText, completion.RecommendedCursorOffset)
+                        {
+                            BriefComment = completion.Description,
+                            Kind = CodeCompletionKind.PropertyPublic
+                        });
                     }
                 }
             }
@@ -145,15 +149,15 @@ namespace AvalonStudio.Languages.Xaml
                 engine = new CompletionEngine();
             }
 
-            if(metaData == null)
-            { 
+            if (metaData == null)
+            {
                 metaData = new MetadataReader(new SrmMetadataProvider()).GetForTargetAssembly(file.Project.Solution.StartupProject.Executable);
             }
         }
-        
+
         public void UnregisterSourceFile(AvaloniaEdit.TextEditor editor, ISourceFile file)
         {
-            
+
         }
 
         public Task<CodeAnalysisResults> RunCodeAnalysisAsync(ISourceFile file, TextDocument textDocument, List<UnsavedFile> unsavedFiles, Func<bool> interruptRequested)

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlLanguageService.cs
@@ -24,7 +24,7 @@ namespace AvalonStudio.Languages.Xaml
             new CompleteCloseTagCodeEditorHelper(),
             new TerminateElementCodeEditorHelper(),
             new InsertQuotesForPropertyValueCodeEditorHelper(),
-            new XamlIndentationCodeEditorHelper()
+            new InsertExtraNewLineBetweenAttributesOnEnterCodeInputHelper()
         };
 
         public IIndentationStrategy IndentationStrategy { get; } = new XamlIndentationStrategy();

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlLanguageService.cs
@@ -77,7 +77,7 @@ namespace AvalonStudio.Languages.Xaml
         {
             bool result = false;
 
-            if (currentChar == '<' || currentChar == ' ')
+            if (currentChar == '<' || currentChar == ' ' || currentChar == '.')
             {
                 return true;
             }
@@ -103,7 +103,8 @@ namespace AvalonStudio.Languages.Xaml
                         results.Completions.Add(new CodeCompletionData(completion.DisplayText, completion.InsertText, completion.RecommendedCursorOffset)
                         {
                             BriefComment = completion.Description,
-                            Kind = CodeCompletionKind.PropertyPublic
+                            Kind = CodeCompletionKind.PropertyPublic,
+                            RecommendImmediateSuggestions = completion.InsertText.Contains("=") || completion.InsertText.EndsWith('.')
                         });
                     }
                 }

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlLanguageService.cs
@@ -13,11 +13,20 @@ using Avalonia.Ide.CompletionEngine.AssemblyMetadata;
 using Avalonia.Ide.CompletionEngine.SrmMetadataProvider;
 using System.Reflection;
 using System.Linq;
+using AvalonStudio.Editor;
 
 namespace AvalonStudio.Languages.Xaml
 {
     class XamlLanguageService : ILanguageService
     {
+        private static List<ICodeEditorInputHelper> s_InputHelpers = new List<ICodeEditorInputHelper>
+        {
+            new CompleteCloseTagCodeEditorHelper(),
+            new TerminateElementCodeEditorHelper(),
+            new InsertQuotesForPropertyValueCodeEditorHelper(),
+            new XamlIndentationCodeEditorHelper()
+        };
+
         public IIndentationStrategy IndentationStrategy => null;
 
         public string Title => "XAML";
@@ -25,6 +34,8 @@ namespace AvalonStudio.Languages.Xaml
         public string LanguageId => "xaml";
 
         public Type BaseTemplateType => null;
+
+        public IEnumerable<ICodeEditorInputHelper> InputHelpers => s_InputHelpers;
 
         public IDictionary<string, Func<string, string>> SnippetCodeGenerators => new Dictionary<string, Func<string, string>>();
 
@@ -132,9 +143,15 @@ namespace AvalonStudio.Languages.Xaml
 
         public void RegisterSourceFile(AvaloniaEdit.TextEditor editor, ISourceFile file, TextDocument textDocument)
         {
-            engine = new CompletionEngine();
-            
-            metaData = new MetadataReader(new SrmMetadataProvider()).GetForTargetAssembly(file.Project.Solution.StartupProject.Executable);
+            if (engine == null)
+            {
+                engine = new CompletionEngine();
+            }
+
+            if(metaData == null)
+            { 
+                metaData = new MetadataReader(new SrmMetadataProvider()).GetForTargetAssembly(file.Project.Solution.StartupProject.Executable);
+            }
         }
         
         public void UnregisterSourceFile(AvaloniaEdit.TextEditor editor, ISourceFile file)

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlLanguageService.cs
@@ -27,7 +27,7 @@ namespace AvalonStudio.Languages.Xaml
             new XamlIndentationCodeEditorHelper()
         };
 
-        public IIndentationStrategy IndentationStrategy => null;
+        public IIndentationStrategy IndentationStrategy { get; } = new XamlIndentationStrategy();
 
         public string Title => "XAML";
 

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlLanguageService.cs
@@ -1,19 +1,16 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading.Tasks;
-using AvaloniaEdit;
-using AvaloniaEdit.Document;
-using AvaloniaEdit.Indentation;
-using AvalonStudio.Extensibility.Languages.CompletionAssistance;
-using AvalonStudio.Projects;
-using System.IO;
-using Avalonia.Ide.CompletionEngine;
+﻿using Avalonia.Ide.CompletionEngine;
 using Avalonia.Ide.CompletionEngine.AssemblyMetadata;
 using Avalonia.Ide.CompletionEngine.SrmMetadataProvider;
-using System.Reflection;
-using System.Linq;
+using AvaloniaEdit.Document;
+using AvaloniaEdit.Indentation;
 using AvalonStudio.Editor;
+using AvalonStudio.Extensibility.Languages.CompletionAssistance;
+using AvalonStudio.Projects;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
 
 namespace AvalonStudio.Languages.Xaml
 {

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlLanguageService.cs
@@ -69,7 +69,7 @@ namespace AvalonStudio.Languages.Xaml
         {
             bool result = false;
 
-            if(currentChar == '<')
+            if(currentChar == '<' || currentChar == ' ')
             {
                 return true;
             }

--- a/AvalonStudio/AvalonStudio.sln
+++ b/AvalonStudio/AvalonStudio.sln
@@ -1,6 +1,6 @@
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.27009.1
+VisualStudioVersion = 15.0.27102.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "AvalonStudio", "AvalonStudio\AvalonStudio.csproj", "{8E501956-B9A6-430E-86AC-350ED94B44E4}"
 EndProject
@@ -97,6 +97,8 @@ EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Ide.CompletionEngine", "Avalonia.Ide\src\Avalonia.Ide.CompletionEngine\Avalonia.Ide.CompletionEngine.csproj", "{BD674D2D-3435-4C8B-BCA1-7344E17EF3AB}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Ide.CompletionEngine.SrmMetadataProvider", "Avalonia.Ide\src\Avalonia.Ide.CompletionEngine.SrmMetadataProvider\Avalonia.Ide.CompletionEngine.SrmMetadataProvider.csproj", "{D6FA36F1-38F8-456E-AF2D-155F9CBDB8D0}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Avalonia.Designer.HostApp", "Avalonia.Designer.HostApp\Avalonia.Designer.HostApp.csproj", "{952217E5-1523-40FA-9808-BBB50344C0F1}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -718,6 +720,22 @@ Global
 		{D6FA36F1-38F8-456E-AF2D-155F9CBDB8D0}.Release|x64.Build.0 = Release|Any CPU
 		{D6FA36F1-38F8-456E-AF2D-155F9CBDB8D0}.Release|x86.ActiveCfg = Release|Any CPU
 		{D6FA36F1-38F8-456E-AF2D-155F9CBDB8D0}.Release|x86.Build.0 = Release|Any CPU
+		{952217E5-1523-40FA-9808-BBB50344C0F1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{952217E5-1523-40FA-9808-BBB50344C0F1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{952217E5-1523-40FA-9808-BBB50344C0F1}.Debug|ARM.ActiveCfg = Debug|Any CPU
+		{952217E5-1523-40FA-9808-BBB50344C0F1}.Debug|ARM.Build.0 = Debug|Any CPU
+		{952217E5-1523-40FA-9808-BBB50344C0F1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{952217E5-1523-40FA-9808-BBB50344C0F1}.Debug|x64.Build.0 = Debug|Any CPU
+		{952217E5-1523-40FA-9808-BBB50344C0F1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{952217E5-1523-40FA-9808-BBB50344C0F1}.Debug|x86.Build.0 = Debug|Any CPU
+		{952217E5-1523-40FA-9808-BBB50344C0F1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{952217E5-1523-40FA-9808-BBB50344C0F1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{952217E5-1523-40FA-9808-BBB50344C0F1}.Release|ARM.ActiveCfg = Release|Any CPU
+		{952217E5-1523-40FA-9808-BBB50344C0F1}.Release|ARM.Build.0 = Release|Any CPU
+		{952217E5-1523-40FA-9808-BBB50344C0F1}.Release|x64.ActiveCfg = Release|Any CPU
+		{952217E5-1523-40FA-9808-BBB50344C0F1}.Release|x64.Build.0 = Release|Any CPU
+		{952217E5-1523-40FA-9808-BBB50344C0F1}.Release|x86.ActiveCfg = Release|Any CPU
+		{952217E5-1523-40FA-9808-BBB50344C0F1}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -757,6 +775,7 @@ Global
 		{BAC6029E-1591-4EC4-90AA-78EEE4E8D50D} = {528C3D32-4210-4109-AE60-B965C6BED1C3}
 		{BD674D2D-3435-4C8B-BCA1-7344E17EF3AB} = {528C3D32-4210-4109-AE60-B965C6BED1C3}
 		{D6FA36F1-38F8-456E-AF2D-155F9CBDB8D0} = {528C3D32-4210-4109-AE60-B965C6BED1C3}
+		{952217E5-1523-40FA-9808-BBB50344C0F1} = {528C3D32-4210-4109-AE60-B965C6BED1C3}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {54EEE82F-58D0-4EF3-990D-CBFA0C11A3D6}

--- a/AvalonStudio/AvalonStudio/App.paml.cs
+++ b/AvalonStudio/AvalonStudio/App.paml.cs
@@ -44,7 +44,7 @@ namespace AvalonStudio
         {
             AvaloniaXamlLoader.Load(this);
 
-            DataTemplates.Add(new ViewLocatorDataTemplate());
+           // DataTemplates.Add(new ViewLocatorDataTemplate());
         }
 
         private static void InitializeLogging()

--- a/AvalonStudio/AvalonStudio/App.paml.cs
+++ b/AvalonStudio/AvalonStudio/App.paml.cs
@@ -3,6 +3,7 @@ using Avalonia.Controls;
 using Avalonia.Diagnostics;
 using Avalonia.Logging.Serilog;
 using Avalonia.Markup.Xaml;
+using AvalonStudio.Controls;
 using AvalonStudio.Extensibility.Projects;
 using AvalonStudio.Platforms;
 using AvalonStudio.Repositories;
@@ -42,6 +43,8 @@ namespace AvalonStudio
         public override void Initialize()
         {
             AvaloniaXamlLoader.Load(this);
+
+            DataTemplates.Add(new ViewLocatorDataTemplate());
         }
 
         private static void InitializeLogging()

--- a/AvalonStudio/AvalonStudio/Controls/DocumentTabControl.paml
+++ b/AvalonStudio/AvalonStudio/Controls/DocumentTabControl.paml
@@ -32,7 +32,10 @@
     <cont:DocumentTabControl.HeaderTemplate>
       <DataTemplate>
         <StackPanel Orientation="Horizontal" Gap="2">
-          <TextBlock Text="{Binding Title}" Margin="2" FontSize="12"/>
+          <StackPanel Orientation="Horizontal" Margin="2" TextBlock.FontSize="12">
+            <TextBlock Text="{Binding Title}" />
+            <TextBlock Text="*" IsVisible="{Binding IsDirty, FallbackValue=False}" />
+          </StackPanel>          
           <Button IsVisible="{Binding IsSelected}" Height="14" Width="14" Command="{Binding CloseCommand}">
             <Button.Styles>
               <Style Selector="Button">

--- a/AvalonStudio/AvalonStudio/Controls/DocumentTabControl.paml
+++ b/AvalonStudio/AvalonStudio/Controls/DocumentTabControl.paml
@@ -36,7 +36,7 @@
             <TextBlock Text="{Binding Title}" />
             <TextBlock Text="*" IsVisible="{Binding IsDirty, FallbackValue=False}" />
           </StackPanel>          
-          <Button IsVisible="{Binding IsSelected}" Height="14" Width="14" Command="{Binding CloseCommand}">
+          <Button IsVisible="{Binding IsSelected}" Height="14" Width="14" Command="{Binding Close}">
             <Button.Styles>
               <Style Selector="Button">
                 <Setter Property="BorderThickness" Value="0"/>

--- a/AvalonStudio/AvalonStudio/Controls/DocumentTabControl.paml
+++ b/AvalonStudio/AvalonStudio/Controls/DocumentTabControl.paml
@@ -11,6 +11,24 @@
       <Setter Property="Foreground" Value="{DynamicResource ThemeForegroundBrush}" />
       <Setter Property="IsVisible" Value="{Binding IsVisible}" />
     </Style>
+    <Style Selector="cont|DocumentTabControl /template/ TabStripItem /template/ Button">
+      <Setter Property="IsVisible" Value="False" />
+    </Style>
+    <Style Selector="cont|DocumentTabControl /template/ TabStripItem:pointerover /template/ Button">
+      <Setter Property="IsVisible" Value="True" />
+    </Style>
+    <Style Selector="cont|DocumentTabControl /template/ TabStripItem:selected /template/ Button">
+      <Setter Property="IsVisible" Value="True" />
+    </Style>
+
+    <Style Selector="cont|DocumentTabControl /template/ TabStripItem /template/ Button">
+      <Setter Property="Background" Value="Transparent" />
+    </Style>
+
+    <Style Selector="cont|DocumentTabControl /template/ TabStripItem:selected /template/ Button:pointerover">
+      <Setter Property="Background" Value="{DynamicResource ApplicationAccentBrushLight}" />
+    </Style>
+    
     <Style Selector="cont|DocumentTabControl /template/ TabStripItem:dockright:selected">
       <Setter Property="Background" Value="#68217A" />
       <Setter Property="Foreground" Value="{DynamicResource ApplicationAccentForegroundBrush}" />
@@ -27,6 +45,10 @@
       <Setter Property="Background" Value="{DynamicResource ApplicationAccentBrushLight}" />
       <Setter Property="Foreground" Value="{DynamicResource ApplicationAccentForegroundBrush}" />
     </Style>
+    <Style Selector="cont|DocumentTabControl /template/ TabStripItem:dockleft:selected:pointerover">
+      <Setter Property="Background" Value="{DynamicResource ApplicationAccentBrush}" />
+      <Setter Property="Foreground" Value="{DynamicResource ApplicationAccentForegroundBrush}" />
+    </Style>
   </UserControl.Styles>
   <cont:DocumentTabControl Items="{Binding Documents}" SelectedItem="{Binding SelectedDocument, Mode=TwoWay}">
     <cont:DocumentTabControl.HeaderTemplate>
@@ -36,32 +58,23 @@
             <TextBlock Text="{Binding Title}" />
             <TextBlock Text="*" IsVisible="{Binding IsDirty, FallbackValue=False}" />
           </StackPanel>          
-          <Button IsVisible="{Binding IsSelected}" Height="14" Width="14" Command="{Binding Close}">
+          <Button Height="14" Width="14" Command="{Binding Close}">
             <Button.Styles>
               <Style Selector="Button">
                 <Setter Property="BorderThickness" Value="0"/>
                 <Setter Property="Padding" Value="0"/>
                 <Setter Property="Margin" Value="0"/>
-                <Setter Property="Background" Value="Transparent" />
-              </Style>
-              <Style Selector="Button:pointerover">
-                <Setter Property="Background" Value="#1c97ea" />
               </Style>
             </Button.Styles>
             <Path Margin="2" Stretch="Uniform" UseLayoutRounding="False" Data="M19,6.41L17.59,5L12,10.59L6.41,5L5,6.41L10.59,12L5,17.59L6.41,19L12,13.41L17.59,19L19,17.59L13.41,12L19,6.41Z" Fill="{DynamicResource ApplicationAccentForegroundBrush}" />
           </Button>
 
-          <Button IsVisible="{Binding IsSelected}" Height="14" Width="14">
+          <Button Height="14" Width="14">
             <Button.Styles>
               <Style Selector="Button">
                 <Setter Property="BorderThickness" Value="0"/>
                 <Setter Property="Padding" Value="0"/>
                 <Setter Property="Margin" Value="0"/>
-                <Setter Property="Background" Value="Transparent" />
-              </Style>
-
-              <Style Selector="Button:pointerover">
-                <Setter Property="Background" Value="{DynamicResource ApplicationAccentBrushLight}" />
               </Style>
             </Button.Styles>
             <Path Margin="2" Stretch="Uniform" UseLayoutRounding="False" Data="M16,12V4H17V2H7V4H8V12L6,14V16H11.2V22H12.8V16H18V14L16,12Z" Fill="{DynamicResource ApplicationAccentForegroundBrush}" />

--- a/AvalonStudio/AvalonStudio/Controls/DocumentTabControlViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/DocumentTabControlViewModel.cs
@@ -47,8 +47,7 @@ namespace AvalonStudio.Controls
             }
             else
             {
-
-                if (TemporaryDocument != null)
+                if (TemporaryDocument != null && TemporaryDocument.IsTemporary)
                 {
                     CloseDocument(TemporaryDocument);
                 }

--- a/AvalonStudio/AvalonStudio/Controls/DocumentTabControlViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/DocumentTabControlViewModel.cs
@@ -47,18 +47,16 @@ namespace AvalonStudio.Controls
             }
             else
             {
-                if (TemporaryDocument != null && TemporaryDocument.IsTemporary)
+                if (TemporaryDocument != null)
                 {
                     CloseDocument(TemporaryDocument);
                 }
-
-                document.IsVisible = true;
+                
                 Documents.Add(document);
                 SelectedDocument = document;
 
                 if (temporary)
                 {
-                    document.IsTemporary = true;
                     TemporaryDocument = document;
                 }
             }
@@ -88,12 +86,9 @@ namespace AvalonStudio.Controls
 
                     if (index < Documents.Count)
                     {
-                        if (Documents[index].IsVisible)
-                        {
-                            foundTab = true;
-                            newSelectedTab = Documents[index];
-                            break;
-                        }
+                        foundTab = true;
+                        newSelectedTab = Documents[index];
+                        break;
                     }
                     else
                     {
@@ -109,12 +104,9 @@ namespace AvalonStudio.Controls
 
                     if (index >= 0)
                     {
-                        if (Documents[index].IsVisible)
-                        {
-                            foundTab = true;
-                            newSelectedTab = Documents[index];
-                            break;
-                        }
+                        foundTab = true;
+                        newSelectedTab = Documents[index];
+                        break;
                     }
                     else
                     {
@@ -131,7 +123,7 @@ namespace AvalonStudio.Controls
             }
 
             Documents.Remove(document);
-            document.OnClose();
+            document.Close();
 
             Dispatcher.UIThread.InvokeAsync(async () =>
             {
@@ -162,21 +154,11 @@ namespace AvalonStudio.Controls
             }
             set
             {
-                if(_selectedDocument != null)
-                {
-                    _selectedDocument.IsSelected = false;
-                }
-
                 this.RaiseAndSetIfChanged(ref _selectedDocument, value);
 
                 if (value is ICodeEditor editor)
                 {
                     editor.TriggerCodeAnalysis();
-                }
-
-                if(_selectedDocument != null)
-                {
-                    value.IsSelected = true;
                 }
             }
         }
@@ -186,17 +168,7 @@ namespace AvalonStudio.Controls
             get { return _temporaryDocument; }
             set
             {
-                if(_temporaryDocument != null)
-                {
-                    _temporaryDocument.IsSelected = false;
-                }
-
                 this.RaiseAndSetIfChanged(ref _temporaryDocument, value);
-
-                if (_temporaryDocument != null)
-                {
-                    _temporaryDocument.IsSelected = true;
-                }
             }
         }
 

--- a/AvalonStudio/AvalonStudio/Controls/Editor/EditorViewModel.cs
+++ b/AvalonStudio/AvalonStudio/Controls/Editor/EditorViewModel.cs
@@ -125,7 +125,7 @@ namespace AvalonStudio.Controls
         {
         }
 
-        public override void OnClose()
+        public override void Close()
         {
             _shell.InvalidateErrors();
         }

--- a/AvalonStudio/AvalonStudio/ShellViewModel.cs
+++ b/AvalonStudio/AvalonStudio/ShellViewModel.cs
@@ -459,12 +459,15 @@ namespace AvalonStudio
 
         public void Save()
         {
-            SelectedDocument?.Save();            
+            if (SelectedDocument is IFileDocumentTabViewModel document)
+            {
+                document.Save();
+            }
         }
 
         public void SaveAll()
         {
-            foreach (var document in DocumentTabs.Documents)
+            foreach (var document in DocumentTabs.Documents.OfType<IFileDocumentTabViewModel>())
             {
                 document.Save();
             }
@@ -640,11 +643,6 @@ namespace AvalonStudio
             {
                 if (DocumentTabs != null)
                 {
-                    if (value == null || (DocumentTabs.TemporaryDocument == value && !value.IsTemporary))
-                    {
-                        DocumentTabs.TemporaryDocument = null;
-                    }
-
                     DocumentTabs.SelectedDocument = value;
                 }
             }

--- a/AvalonStudio/AvalonStudio/ShellViewModel.cs
+++ b/AvalonStudio/AvalonStudio/ShellViewModel.cs
@@ -459,15 +459,12 @@ namespace AvalonStudio
 
         public void Save()
         {
-            if (SelectedDocument is ICodeEditor)
-            {
-                (SelectedDocument as ICodeEditor).Save();
-            }
+            SelectedDocument?.Save();            
         }
 
         public void SaveAll()
         {
-            foreach (var document in DocumentTabs.Documents.OfType<EditorViewModel>().Where(d => d.IsDirty && d.IsVisible))
+            foreach (var document in DocumentTabs.Documents)
             {
                 document.Save();
             }

--- a/AvalonStudio/Avalonia.Designer.HostApp/Avalonia.Designer.HostApp.csproj
+++ b/AvalonStudio/Avalonia.Designer.HostApp/Avalonia.Designer.HostApp.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia.Desktop">
-      <Version>0.5.2-build4218-alpha</Version>
+      <Version>0.5.2-build4207-alpha</Version>
     </PackageReference>
   </ItemGroup>
 </Project>

--- a/AvalonStudio/Avalonia.Designer.HostApp/Avalonia.Designer.HostApp.csproj
+++ b/AvalonStudio/Avalonia.Designer.HostApp/Avalonia.Designer.HostApp.csproj
@@ -1,0 +1,12 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFrameworks>netcoreapp2.0</TargetFrameworks>
+      
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Avalonia.Desktop">
+      <Version>0.5.2-build4218-alpha</Version>
+    </PackageReference>
+  </ItemGroup>
+</Project>

--- a/AvalonStudio/Avalonia.Designer.HostApp/Program.cs
+++ b/AvalonStudio/Avalonia.Designer.HostApp/Program.cs
@@ -1,0 +1,10 @@
+﻿
+
+namespace Avalonia.Designer.HostApp
+{
+    class Program
+    {
+        public static void Main(string[] args) 
+            => Avalonia.DesignerSupport.Remote.RemoteDesignerEntryPoint.Main(args);
+    }
+}


### PR DESCRIPTION
- [ ] Allow static highlighting definitions to be provided via language services.
- [x] Allow IKeyboardFilters to be provided via language service.
- [ ] Separate into XML and XAML language services.
- [x] Implement indentation code as an indentation strategy.
- [ ] auto rename closing / opening tag.
- [ ] use editor theme for syntax highlighting.