### PR TITLE
Implemented simple extension discovery

### DIFF
--- a/AvalonStudio/AvalonStudio.Extensibility/ExtensionManager.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/ExtensionManager.cs
@@ -1,0 +1,37 @@
+﻿using AvalonStudio.Platforms;
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+namespace AvalonStudio.Extensibility
+{
+    public class ExtensionManager
+    {
+        public IEnumerable<IExtensionManifest> LoadExtensions()
+        {
+            foreach (var directory in Directory.GetDirectories(Platform.ExtensionsFolder))
+            {
+                var extensionManifest = Path.Combine(directory, "extension.json");
+
+                if (File.Exists(extensionManifest))
+                {
+                    IExtensionManifest extension = null;
+
+                    try
+                    {
+                        extension = ExtensionManifest.LoadFromManifest(extensionManifest);
+                    }
+                    catch (Exception e)
+                    {
+                        // todo: log exception
+                    }
+
+                    if (extension != null)
+                    {
+                        yield return extension;
+                    }
+                }
+            }
+        }
+    }
+}

--- a/AvalonStudio/AvalonStudio.Extensibility/ExtensionManifest.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/ExtensionManifest.cs
@@ -1,0 +1,53 @@
+﻿using Newtonsoft.Json;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+
+namespace AvalonStudio.Extensibility
+{
+    internal class ExtensionManifest : IExtensionManifest
+    {
+        private const string MefComponentsString = "mefComponents";
+
+        [JsonProperty(Required = Required.Always)]
+        public string Name { get; set; }
+        [JsonProperty(Required = Required.Always)]
+        public string Version { get; set; }
+        public string Description { get; set; }
+        public string Icon { get; set; }
+
+        [JsonProperty(Required = Required.Always)]
+        public IDictionary<string, IEnumerable<string>> Assets { get; set; }
+        
+        [JsonExtensionData]
+        public IDictionary<string, object> AdditionalData { get; set; }
+
+        private string _directory;
+
+        public ExtensionManifest(string manifestPath)
+        {
+            _directory = Path.GetDirectoryName(manifestPath);
+        }
+
+        public IEnumerable<string> GetMefComponents()
+        {
+            if (Assets.TryGetValue(MefComponentsString, out var assemblies))
+            {
+                return assemblies.Select(a => Path.Combine(_directory, a));
+            }
+
+            return Enumerable.Empty<string>();
+        }
+
+        public static IExtensionManifest LoadFromManifest(string extensionManifestPath)
+        {
+            using (var reader = new StreamReader(extensionManifestPath))
+            {
+                var extension = new ExtensionManifest(extensionManifestPath);
+                JsonSerializer.Create().Populate(reader, extension);
+
+                return extension;
+            }
+        }
+    }
+}

--- a/AvalonStudio/AvalonStudio.Extensibility/IExtensionManifest.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/IExtensionManifest.cs
@@ -1,0 +1,18 @@
+﻿using System.Collections.Generic;
+
+namespace AvalonStudio.Extensibility
+{
+    public interface IExtensionManifest
+    {
+        string Name { get; }
+        string Version { get; }
+        string Description { get; }
+        string Icon { get; }
+
+        IDictionary<string, IEnumerable<string>> Assets { get; }
+
+        IDictionary<string, object> AdditionalData { get; set; }
+
+        IEnumerable<string> GetMefComponents();
+    }
+}

--- a/AvalonStudio/AvalonStudio.Extensibility/Platform/Platform.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Platform/Platform.cs
@@ -372,6 +372,11 @@ namespace AvalonStudio.Platforms
             {
                 Directory.CreateDirectory(InBuiltSnippetsFolder);
             }
+
+            if (!Directory.Exists(ExtensionsFolder))
+            {
+                Directory.CreateDirectory(ExtensionsFolder);
+            }
         }
 
         public static void OpenFolderInExplorer(string path)

--- a/AvalonStudio/AvalonStudio/App.paml.cs
+++ b/AvalonStudio/AvalonStudio/App.paml.cs
@@ -3,11 +3,13 @@ using Avalonia.Controls;
 using Avalonia.Diagnostics;
 using Avalonia.Logging.Serilog;
 using Avalonia.Markup.Xaml;
+using AvalonStudio.Extensibility;
 using AvalonStudio.Packages;
 using AvalonStudio.Platforms;
 using AvalonStudio.Repositories;
 using Serilog;
 using System;
+using System.Linq;
 
 namespace AvalonStudio
 {
@@ -27,7 +29,9 @@ namespace AvalonStudio
 
                 PackageSources.InitialisePackageSources();
 
-                var container = CompositionRoot.CreateContainer();
+                var extensionManager = new ExtensionManager();
+                var extensions = extensionManager.LoadExtensions();
+                var container = CompositionRoot.CreateContainer(extensions);
 
                 ShellViewModel.Instance = container.GetExport<ShellViewModel>();
 


### PR DESCRIPTION
## Changes
- Added support for simple extension discovery:
    - Extensions are loaded from the `Extensions` folder.
    - Extensions are discovered by their manifest (`extension.json`), which should be placed in the root of the extension folder, with the following format:
    ```
    {
        "name": "Extension Name",
        "version": "1.0.0",
        "description": "Some description for the extension.",
        "icon": "path/to/icon",
        "assets": {
            "mefComponents": [
                "ExtensionAssembly.dll"
            ]
        }
    }
    ```
    - Assemblies specified in `mefComponents` are loaded and added to the composition host.