### PR TITLE
free up the fileSystem watchers when projects are unloaded.

### DIFF
--- a/AvalonStudio/AvalonStudio.Extensibility/Projects/FileSystemProject.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Projects/FileSystemProject.cs
@@ -493,6 +493,12 @@
             return this.DefaultCompareTo(other);
         }
 
-        public abstract Task UnloadAsync();
+        public virtual Task UnloadAsync()
+        {
+            fileSystemWatcher?.Dispose();
+            folderSystemWatcher?.Dispose();
+
+            return Task.CompletedTask;
+        }
     }
 }

--- a/AvalonStudio/AvalonStudio.LanguageSupport.TypeScript/Projects/TypeScriptProject.cs
+++ b/AvalonStudio/AvalonStudio.LanguageSupport.TypeScript/Projects/TypeScriptProject.cs
@@ -223,9 +223,9 @@ Program.main();
             SerializedObject.Serialize(Location, this); //Write the project
         }
 
-        public override Task UnloadAsync()
+        public async override Task UnloadAsync()
         {
-            return Task.CompletedTask;
+            await base.UnloadAsync();
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.LanguageSupport.TypeScript/Projects/TypeScriptProject.cs
+++ b/AvalonStudio/AvalonStudio.LanguageSupport.TypeScript/Projects/TypeScriptProject.cs
@@ -222,10 +222,5 @@ Program.main();
             //TODO: Anything with references?
             SerializedObject.Serialize(Location, this); //Write the project
         }
-
-        public async override Task UnloadAsync()
-        {
-            await base.UnloadAsync();
-        }
     }
 }

--- a/AvalonStudio/AvalonStudio.Projects.CPlusPlus/CPlusPlusProject.cs
+++ b/AvalonStudio/AvalonStudio.Projects.CPlusPlus/CPlusPlusProject.cs
@@ -693,10 +693,5 @@ namespace AvalonStudio.Projects.CPlusPlus
         {
             return Name.CompareTo(other.Name);
         }
-
-        public async override Task UnloadAsync()
-        {
-            await base.UnloadAsync();
-        }
     }
 }

--- a/AvalonStudio/AvalonStudio.Projects.CPlusPlus/CPlusPlusProject.cs
+++ b/AvalonStudio/AvalonStudio.Projects.CPlusPlus/CPlusPlusProject.cs
@@ -694,9 +694,9 @@ namespace AvalonStudio.Projects.CPlusPlus
             return Name.CompareTo(other.Name);
         }
 
-        public override Task UnloadAsync()
+        public async override Task UnloadAsync()
         {
-            return Task.CompletedTask;
+            await base.UnloadAsync();
         }
     }
 }

--- a/AvalonStudio/AvalonStudio.Projects.OmniSharp/OmniSharpProject.cs
+++ b/AvalonStudio/AvalonStudio.Projects.OmniSharp/OmniSharpProject.cs
@@ -350,8 +350,10 @@ namespace AvalonStudio.Projects.OmniSharp
 
         private static object s_unloadLock = new object();
 
-        public override Task UnloadAsync()
+        public override async Task UnloadAsync()
         {
+            await base.UnloadAsync();
+
             lock (s_unloadLock)
             {                
                 RoslynProject = null;
@@ -363,8 +365,6 @@ namespace AvalonStudio.Projects.OmniSharp
                     RoslynWorkspace.DisposeWorkspace(Solution);                    
                 }
             }
-
-            return Task.CompletedTask;
         }
 
         public override List<string> ExcludedFiles { get; set; }

--- a/AvalonStudio/AvalonStudio.Projects.OmniSharp/OmniSharpProject.cs
+++ b/AvalonStudio/AvalonStudio.Projects.OmniSharp/OmniSharpProject.cs
@@ -25,6 +25,8 @@ namespace AvalonStudio.Projects.OmniSharp
     public class OmniSharpProject : FileSystemProject
     {
         private string detectedTargetPath;
+        private FileSystemWatcher fileWatcher;
+
         public static async Task<OmniSharpProject> Create(ISolution solution, string path)
         {
             var (project, projectReferences, targetPath) = await RoslynWorkspace.GetWorkspace(solution).AddProject(solution.CurrentDirectory, path);
@@ -65,7 +67,7 @@ namespace AvalonStudio.Projects.OmniSharp
 
             try
             {
-                var fileWatcher = new FileSystemWatcher(CurrentDirectory, Path.GetFileName(Location))
+                fileWatcher = new FileSystemWatcher(CurrentDirectory, Path.GetFileName(Location))
                 {
                     EnableRaisingEvents = true,
                     IncludeSubdirectories = false,
@@ -353,6 +355,8 @@ namespace AvalonStudio.Projects.OmniSharp
         public override async Task UnloadAsync()
         {
             await base.UnloadAsync();
+
+            fileWatcher?.Dispose();
 
             lock (s_unloadLock)
             {                


### PR DESCRIPTION
**Changes**
When projects are unloaded, then the filesystem watchers were not disposed. On Linux this quickly becomes a problem using up INotify limit.

- call Dispose on the file and folder watchers,
- call Dispose on the csproj file watchers 