### PR TITLE
Removed extension assembly loading

### DIFF
--- a/AvalonStudio/AvalonStudio.Controls.Standard/ExtensionManagerDialog/ExtensionManagerDialogViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/ExtensionManagerDialog/ExtensionManagerDialogViewModel.cs
@@ -6,16 +6,16 @@ namespace AvalonStudio.Controls.Standard.ExtensionManagerDialog
 {
     public class ExtensionManagerDialogViewModel : DocumentTabViewModel
     {
-        private ExtensionManager _extensionManager;
+        private IExtensionManager _extensionManager;
 
         private ObservableCollection<IExtensionManifest> _installedExtensions;
         private IExtensionManifest _selectedExtension;
 
-        public ExtensionManagerDialogViewModel()
+        public ExtensionManagerDialogViewModel(IExtensionManager extensionManager)
         {
             Title = "Extensions";
 
-            _extensionManager = IoC.Get<ExtensionManager>();
+            _extensionManager = extensionManager;
             _installedExtensions = new ObservableCollection<IExtensionManifest>(_extensionManager.GetInstalledExtensions());
         }
 

--- a/AvalonStudio/AvalonStudio.Extensibility/ExtensionManager.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/ExtensionManager.cs
@@ -1,26 +1,18 @@
 ﻿using AvalonStudio.Platforms;
 using System;
 using System.Collections.Generic;
+using System.Composition;
 using System.IO;
 
 namespace AvalonStudio.Extensibility
 {
-    public sealed class ExtensionManager
+    [Export(typeof(IExtensionManager))]
+    [Shared]
+    internal class ExtensionManager : IExtensionManager
     {
         private const string ExtensionManifestFilename = "extension.json";
 
         private IEnumerable<IExtensionManifest> _installedExtensions;
-
-        private ExtensionManager() { }
-
-        public static void Initialise()
-        {
-            if (IoC.Get<ExtensionManager>() == null)
-            {
-                var extensionManager = new ExtensionManager();
-                IoC.RegisterConstant(extensionManager);
-            }
-        }
 
         public IEnumerable<IExtensionManifest> GetInstalledExtensions()
         {

--- a/AvalonStudio/AvalonStudio.Extensibility/IExtensionManager.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/IExtensionManager.cs
@@ -1,0 +1,9 @@
+﻿using System.Collections.Generic;
+
+namespace AvalonStudio.Extensibility
+{
+    public interface IExtensionManager
+    {
+        IEnumerable<IExtensionManifest> GetInstalledExtensions();
+    }
+}

--- a/AvalonStudio/AvalonStudio/App.paml.cs
+++ b/AvalonStudio/AvalonStudio/App.paml.cs
@@ -3,7 +3,6 @@ using Avalonia.Controls;
 using Avalonia.Diagnostics;
 using Avalonia.Logging.Serilog;
 using Avalonia.Markup.Xaml;
-using AvalonStudio.Extensibility;
 using AvalonStudio.Packages;
 using AvalonStudio.Platforms;
 using AvalonStudio.Repositories;
@@ -24,19 +23,14 @@ namespace AvalonStudio
 
             var builder = AppBuilder.Configure<App>().UseReactiveUI().AvalonStudioPlatformDetect().AfterSetup(async _ =>
             {
+                var container = CompositionRoot.CreateContainer();
+
                 Platform.Initialise();
-
                 PackageSources.InitialisePackageSources();
-
-                ExtensionManager.Initialise();
-
-                var extensionManager = IoC.Get<ExtensionManager>();
-                var extensions = extensionManager.GetInstalledExtensions();
-                var container = CompositionRoot.CreateContainer(extensions);
 
                 ShellViewModel.Instance = container.GetExport<ShellViewModel>();
 
-                await PackageManager.LoadAssetsAsync();
+                await PackageManager.LoadAssetsAsync().ConfigureAwait(false);
             });
 
             InitializeLogging();

--- a/AvalonStudio/AvalonStudio/CompositionRoot.cs
+++ b/AvalonStudio/AvalonStudio/CompositionRoot.cs
@@ -1,17 +1,15 @@
-using AvalonStudio.Extensibility;
 using AvalonStudio.Extensibility.Plugin;
 using AvalonStudio.Extensibility.Utils;
 using System.Collections.Generic;
 using System.Composition.Convention;
 using System.Composition.Hosting;
-using System.Linq;
 using System.Reflection;
 
 namespace AvalonStudio
 {
     internal static class CompositionRoot
     {
-        public static CompositionHost CreateContainer(IEnumerable<IExtensionManifest> extensions)
+        public static CompositionHost CreateContainer()
         {
             var conventions = new ConventionBuilder();
             conventions.ForTypesDerivedFrom<IExtension>().Export<IExtension>();
@@ -20,21 +18,6 @@ namespace AvalonStudio
             // to load any assembly in the bin directory (so not really appdomain) we need to get rid of this
             // once all our default extensions are published with a manifest and copied to extensions dir.
             IEnumerable<Assembly> assemblies = AppDomain.CurrentDomain.GetAssemblies();
-
-            foreach (var extension in extensions)
-            {
-                foreach (var assembly in extension.GetMefComponents())
-                {
-                    try
-                    {
-                        assemblies = assemblies.Append(Assembly.LoadFrom(assembly));
-                    }
-                    catch (System.Exception e)
-                    {
-                        // todo: log exception
-                    }
-                }
-            }
 
             var configuration = new ContainerConfiguration().WithAssemblies(assemblies, conventions);
             return configuration.CreateContainer();

--- a/AvalonStudio/AvalonStudio/MainWindow.paml.cs
+++ b/AvalonStudio/AvalonStudio/MainWindow.paml.cs
@@ -1,14 +1,8 @@
 using Avalonia;
-using Avalonia.Controls;
 using Avalonia.Markup.Xaml;
-using Avalonia.Media;
-using Avalonia.Threading;
 using AvalonStudio.Controls;
-using AvalonStudio.Controls.Standard.SettingsDialog;
-using AvalonStudio.Extensibility;
 using AvalonStudio.Extensibility.Theme;
 using AvalonStudio.GlobalSettings;
-using System;
 
 namespace AvalonStudio
 {
@@ -16,16 +10,13 @@ namespace AvalonStudio
     {
         public MainWindow()
         {
-            IoC.RegisterConstant<Window>(this);
-
             InitializeComponent();
 
             DataContext = ShellViewModel.Instance;
 
-            KeyBindings.AddRange(IoC.Get<ShellViewModel>().KeyBindings);
+            KeyBindings.AddRange(ShellViewModel.Instance.KeyBindings);
 
             var generalSettings = Settings.GetSettings<GeneralSettings>();
-
             ColorTheme.LoadTheme(generalSettings.Theme);
 
             this.AttachDevTools();

--- a/AvalonStudio/AvalonStudio/Shell/Commands/ExtensionsCommandDefinition.cs
+++ b/AvalonStudio/AvalonStudio/Shell/Commands/ExtensionsCommandDefinition.cs
@@ -2,6 +2,7 @@
 using AvalonStudio.Extensibility;
 using AvalonStudio.Extensibility.Commands;
 using ReactiveUI;
+using System.Composition;
 using System.Windows.Input;
 
 namespace AvalonStudio.Shell.Commands
@@ -10,13 +11,14 @@ namespace AvalonStudio.Shell.Commands
     {
         private ReactiveCommand _command;
 
-        public ExtensionsCommandDefinition()
+        [ImportingConstructor]
+        public ExtensionsCommandDefinition(IExtensionManager extensionManager)
         {
             _command = ReactiveCommand.Create(
                 () =>
                 {
                     var shell = IoC.Get<IShell>();
-                    shell.AddDocument(new ExtensionManagerDialogViewModel());
+                    shell.AddDocument(new ExtensionManagerDialogViewModel(extensionManager));
                 });
         }
 


### PR DESCRIPTION
## Changes
- Removed extension assembly loading for now, as extensions should be loaded by the shell parts which use them, in separate composition contexts.
- Extracted interface for ExtensionManager.