### PR TITLE
Using MEF for extensions

### DIFF
--- a/AvalonStudio/AvalonStudio.Extensibility/Editor/IEditorProvider.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Editor/IEditorProvider.cs
@@ -1,11 +1,9 @@
-﻿using AvalonStudio.Controls;
-using AvalonStudio.Documents;
-using AvalonStudio.Extensibility.Plugin;
+﻿using AvalonStudio.Documents;
 using AvalonStudio.Projects;
 
 namespace AvalonStudio.Extensibility.Editor
 {
-    public interface IEditorProvider : IExtension
+    public interface IEditorProvider
     {
         bool CanEdit(ISourceFile file);
 

--- a/AvalonStudio/AvalonStudio.Extensibility/Shell/IShell.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Shell/IShell.cs
@@ -45,8 +45,6 @@ namespace AvalonStudio.Shell
 
         ColorScheme CurrentColorScheme { get; set; }
 
-        IEnumerable<IEditorProvider> EditorProviders { get; }
-
         IEnumerable<ISolutionType> SolutionTypes { get; }
 
         IEnumerable<IProjectType> ProjectTypes { get; }

--- a/AvalonStudio/AvalonStudio.Languages.CSharp/MetaDataEditorProvider.cs
+++ b/AvalonStudio/AvalonStudio.Languages.CSharp/MetaDataEditorProvider.cs
@@ -1,24 +1,13 @@
 ﻿using AvalonStudio.Documents;
 using AvalonStudio.Extensibility.Editor;
 using AvalonStudio.Projects;
-using System;
-using System.Collections.Generic;
-using System.Text;
+using System.Composition;
 
 namespace AvalonStudio.Languages.CSharp
 {
-    class MetaDataEditorProvider : IEditorProvider
+    [Export(typeof(IEditorProvider))]
+    internal class MetaDataEditorProvider : IEditorProvider
     {
-        public void Activation()
-        {
-            
-        }
-
-        public void BeforeActivation()
-        {
-            
-        }
-
         public bool CanEdit(ISourceFile file)
         {
             return file.FilePath.StartsWith("$metadata");

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorProvider.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorProvider.cs
@@ -1,20 +1,13 @@
-﻿using AvalonStudio.Controls;
-using AvalonStudio.Documents;
+﻿using AvalonStudio.Documents;
 using AvalonStudio.Extensibility.Editor;
 using AvalonStudio.Projects;
+using System.Composition;
 
 namespace AvalonStudio.Languages.Xaml
 {
-    public class XamlEditorProvider : IEditorProvider
+    [Export(typeof(IEditorProvider))]
+    internal class XamlEditorProvider : IEditorProvider
     {
-        public void Activation()
-        {
-        }
-
-        public void BeforeActivation()
-        {
-        }
-
         public bool CanEdit(ISourceFile file)
         {
             bool result = false;

--- a/AvalonStudio/AvalonStudio.MiniShell/MinimalShell.cs
+++ b/AvalonStudio/AvalonStudio.MiniShell/MinimalShell.cs
@@ -30,7 +30,6 @@ namespace AvalonStudio.Shell
         private List<IToolChain> _toolChains;
         private List<IDebugger> _debugger2s;
         private List<ITestFramework> _testFrameworks;
-        private List<IEditorProvider> _editorProviders;
 
         public event EventHandler<FileOpenedEventArgs> FileOpened;
         public event EventHandler<FileOpenedEventArgs> FileClosed;
@@ -63,7 +62,6 @@ namespace AvalonStudio.Shell
                 _solutionTypes.ConsumeExtension(extension);
                 _projectTypes.ConsumeExtension(extension);
                 _testFrameworks.ConsumeExtension(extension);
-                _editorProviders.ConsumeExtension(extension);
             }
 
             IoC.RegisterConstant(this);
@@ -146,8 +144,6 @@ namespace AvalonStudio.Shell
         public IWorkspaceTaskRunner TaskRunner => throw new NotImplementedException();
 
         public ColorScheme CurrentColorScheme { get => throw new NotImplementedException(); set => throw new NotImplementedException(); }
-
-        public IEnumerable<IEditorProvider> EditorProviders => _editorProviders;
 
         public IEditor OpenDocument(ISourceFile file, int line, int startColumn = -1, int endColumn = -1, bool debugHighlight = false,
             bool selectLine = false, bool focus = true)

--- a/AvalonStudio/AvalonStudio.MiniShell/MinimalShell.cs
+++ b/AvalonStudio/AvalonStudio.MiniShell/MinimalShell.cs
@@ -1,6 +1,5 @@
 namespace AvalonStudio.Shell
 {
-    using AvalonStudio.Controls;
     using AvalonStudio.Debugging;
     using AvalonStudio.Documents;
     using AvalonStudio.Extensibility;
@@ -19,6 +18,8 @@ namespace AvalonStudio.Shell
     using AvalonStudio.Extensibility.MainMenu;
 
     [Export]
+    [Export(typeof(IShell))]
+    [Shared]
     public class MinimalShell : IShell
     {
         public static IShell Instance { get; set; }

--- a/AvalonStudio/AvalonStudio/App.paml.cs
+++ b/AvalonStudio/AvalonStudio/App.paml.cs
@@ -6,6 +6,7 @@ using AvalonStudio.Platforms;
 using AvalonStudio.Repositories;
 using Serilog;
 using System;
+using System.Composition;
 
 namespace AvalonStudio
 {
@@ -33,12 +34,14 @@ namespace AvalonStudio
 
                 var builder = BuildAvaloniaApp().AfterSetup(async _ =>
                 {
-                    var container = CompositionRoot.CreateContainer();
+                    var extensionManager = new ExtensionManager();
+                    var container = CompositionRoot.CreateContainer(extensionManager);
 
                     Platform.Initialise();
                     PackageSources.InitialisePackageSources();
 
-                    ShellViewModel.Instance = container.GetExport<ShellViewModel>();
+                    var shellExportFactory = container.GetExport<ExportFactory<ShellViewModel>>();
+                    ShellViewModel.Instance = shellExportFactory.CreateExport().Value;
 
                     await PackageManager.LoadAssetsAsync().ConfigureAwait(false);
                 });

--- a/AvalonStudio/AvalonStudio/CompositionRoot.cs
+++ b/AvalonStudio/AvalonStudio/CompositionRoot.cs
@@ -1,3 +1,4 @@
+using AvalonStudio.Extensibility;
 using AvalonStudio.Extensibility.Plugin;
 using AvalonStudio.Extensibility.Utils;
 using System.Collections.Generic;
@@ -9,7 +10,7 @@ namespace AvalonStudio
 {
     internal static class CompositionRoot
     {
-        public static CompositionHost CreateContainer()
+        public static CompositionHost CreateContainer(ExtensionManager extensionManager)
         {
             var conventions = new ConventionBuilder();
             conventions.ForTypesDerivedFrom<IExtension>().Export<IExtension>();
@@ -17,10 +18,36 @@ namespace AvalonStudio
             // TODO AppDomain here is a custom appdomain from namespace AvalonStudio.Extensibility.Utils. It is able
             // to load any assembly in the bin directory (so not really appdomain) we need to get rid of this
             // once all our default extensions are published with a manifest and copied to extensions dir.
-            IEnumerable<Assembly> assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            var assemblies = AppDomain.CurrentDomain.GetAssemblies();
+            var extensionAssemblies = LoadMefComponents(extensionManager);
 
-            var configuration = new ContainerConfiguration().WithAssemblies(assemblies, conventions);
+            var configuration = new ContainerConfiguration()
+                .WithAssemblies(assemblies, conventions)
+                .WithAssemblies(extensionAssemblies);
             return configuration.CreateContainer();
+        }
+
+        private static IEnumerable<Assembly> LoadMefComponents(ExtensionManager extensionManager)
+        {
+            var assemblies = new List<Assembly>();
+
+            foreach (var extension in extensionManager.GetInstalledExtensions())
+            {
+                foreach (var mefComponent in extension.GetMefComponents())
+                {
+                    try
+                    {
+                        assemblies.Add(Assembly.LoadFrom(mefComponent));
+                    }
+                    catch (System.Exception e)
+                    {
+                        System.Console.WriteLine($"Failed to load MEF component from extension: '{mefComponent}'");
+                        System.Console.WriteLine(e.ToString());
+                    }
+                }
+            }
+
+            return assemblies;
         }
     }
 }

--- a/AvalonStudio/AvalonStudio/ExtensionManager.cs
+++ b/AvalonStudio/AvalonStudio/ExtensionManager.cs
@@ -1,10 +1,11 @@
-﻿using AvalonStudio.Platforms;
+﻿using AvalonStudio.Extensibility;
+using AvalonStudio.Platforms;
 using System;
 using System.Collections.Generic;
 using System.Composition;
 using System.IO;
 
-namespace AvalonStudio.Extensibility
+namespace AvalonStudio
 {
     [Export(typeof(IExtensionManager))]
     [Shared]
@@ -12,19 +13,11 @@ namespace AvalonStudio.Extensibility
     {
         private const string ExtensionManifestFilename = "extension.json";
 
-        private IEnumerable<IExtensionManifest> _installedExtensions;
+        private static Lazy<IEnumerable<IExtensionManifest>> _installedExtensions = new Lazy<IEnumerable<IExtensionManifest>>(LoadExtensions);
 
-        public IEnumerable<IExtensionManifest> GetInstalledExtensions()
-        {
-            if (_installedExtensions == null)
-            {
-                _installedExtensions = LoadExtensions();
-            }
+        public IEnumerable<IExtensionManifest> GetInstalledExtensions() => _installedExtensions.Value;
 
-            return _installedExtensions;
-        }
-
-        private List<IExtensionManifest> LoadExtensions()
+        private static List<IExtensionManifest> LoadExtensions()
         {
             var extensions = new List<IExtensionManifest>();
 

--- a/AvalonStudio/AvalonStudio/ExtensionManifest.cs
+++ b/AvalonStudio/AvalonStudio/ExtensionManifest.cs
@@ -1,11 +1,12 @@
-﻿using AvalonStudio.Utils;
+﻿using AvalonStudio.Extensibility;
+using AvalonStudio.Utils;
 using Newtonsoft.Json;
-using System.Collections.Generic;
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 
-namespace AvalonStudio.Extensibility
+namespace AvalonStudio
 {
     internal class ExtensionManifest : IExtensionManifest
     {

--- a/AvalonStudio/AvalonStudio/ShellViewModel.cs
+++ b/AvalonStudio/AvalonStudio/ShellViewModel.cs
@@ -1,9 +1,7 @@
 using Avalonia.Input;
 using Avalonia.Threading;
 using AvalonStudio.Controls;
-using AvalonStudio.Controls.Standard.CodeEditor;
 using AvalonStudio.Controls.Standard.ErrorList;
-using AvalonStudio.Extensibility.Templating;
 using AvalonStudio.Debugging;
 using AvalonStudio.Documents;
 using AvalonStudio.Extensibility;
@@ -14,12 +12,12 @@ using AvalonStudio.Extensibility.MainMenu;
 using AvalonStudio.Extensibility.MainToolBar;
 using AvalonStudio.Extensibility.Menus;
 using AvalonStudio.Extensibility.Plugin;
+using AvalonStudio.Extensibility.Shell;
 using AvalonStudio.Extensibility.ToolBars;
 using AvalonStudio.Extensibility.ToolBars.Models;
 using AvalonStudio.GlobalSettings;
 using AvalonStudio.Languages;
 using AvalonStudio.MVVM;
-using AvalonStudio.Platforms;
 using AvalonStudio.Projects;
 using AvalonStudio.Shell;
 using AvalonStudio.TestFrameworks;
@@ -34,12 +32,13 @@ using System.Linq;
 using System.Reactive.Linq;
 using System.Threading;
 using System.Threading.Tasks;
-using AvalonStudio.Extensibility.Shell;
 
 namespace AvalonStudio
 {
     [Export]
-    public class ShellViewModel : ViewModel, IShell
+    [Export(typeof(IShell))]
+    [Shared]
+    internal class ShellViewModel : ViewModel, IShell
     {
         public static ShellViewModel Instance { get; internal set; }
         private IToolBar _toolBar;
@@ -254,8 +253,6 @@ namespace AvalonStudio
             var editorSettings = Settings.GetSettings<EditorSettings>();
 
             _globalZoomLevel = editorSettings.GlobalZoomLevel;
-
-            IoC.RegisterConstant(this);
 
             this.WhenAnyValue(x => x.GlobalZoomLevel).Subscribe(zoomLevel =>
             {


### PR DESCRIPTION
## Changes
- Added back extension assembly loading.
- Moved `ExtensionManager` and `ExtensionManifest` to AvalonStudio.
- Changed editor provider loading to use MEF.

I'll upgrade other extensibility points to use MEF one by one, as it may require some changes.