### PR TITLE
Moved IEditorProvider to the AvalonStudio.Shell namespace

### DIFF
--- a/AvalonStudio/AvalonStudio.Extensibility/Shell/ExportEditorProviderAttribute.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Shell/ExportEditorProviderAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Composition;
+
+namespace AvalonStudio.Shell
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class ExportEditorProviderAttribute : ExportAttribute
+    {
+        public ExportEditorProviderAttribute()
+            : base(typeof(IEditorProvider))
+        {
+        }
+    }
+}

--- a/AvalonStudio/AvalonStudio.Extensibility/Shell/IEditorProvider.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Shell/IEditorProvider.cs
@@ -1,12 +1,11 @@
 ﻿using AvalonStudio.Documents;
 using AvalonStudio.Projects;
 
-namespace AvalonStudio.Extensibility.Editor
+namespace AvalonStudio.Shell
 {
     public interface IEditorProvider
     {
         bool CanEdit(ISourceFile file);
-
         IFileDocumentTabViewModel CreateViewModel(ISourceFile file);
     }
 }

--- a/AvalonStudio/AvalonStudio.Languages.CSharp/MetaDataEditorProvider.cs
+++ b/AvalonStudio/AvalonStudio.Languages.CSharp/MetaDataEditorProvider.cs
@@ -1,11 +1,11 @@
 ﻿using AvalonStudio.Documents;
 using AvalonStudio.Extensibility.Editor;
 using AvalonStudio.Projects;
-using System.Composition;
+using AvalonStudio.Shell;
 
 namespace AvalonStudio.Languages.CSharp
 {
-    [Export(typeof(IEditorProvider))]
+    [ExportEditorProvider]
     internal class MetaDataEditorProvider : IEditorProvider
     {
         public bool CanEdit(ISourceFile file)

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorProvider.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlEditorProvider.cs
@@ -1,11 +1,10 @@
 ﻿using AvalonStudio.Documents;
-using AvalonStudio.Extensibility.Editor;
 using AvalonStudio.Projects;
-using System.Composition;
+using AvalonStudio.Shell;
 
 namespace AvalonStudio.Languages.Xaml
 {
-    [Export(typeof(IEditorProvider))]
+    [ExportEditorProvider]
     internal class XamlEditorProvider : IEditorProvider
     {
         public bool CanEdit(ISourceFile file)


### PR DESCRIPTION
## Changes
- Moved IEditorProvider to the AvalonStudio.Shell namespace.