### PR TITLE
Language service cleanup

### DIFF
--- a/AvalonStudio/AvalonStudio.Controls.Standard.Tests/TestLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard.Tests/TestLanguageService.cs
@@ -5,7 +5,6 @@ using AvalonStudio.Extensibility.Languages.CompletionAssistance;
 using AvalonStudio.Languages;
 using System;
 using System.Collections.Generic;
-using System.Threading;
 using System.Threading.Tasks;
 
 namespace AvalonStudio.Controls.Standard.Tests
@@ -23,10 +22,6 @@ namespace AvalonStudio.Controls.Standard.Tests
         public string LanguageId => "cpp";
 
         public IIndentationStrategy IndentationStrategy => throw new NotImplementedException();
-
-        public string Title => throw new NotImplementedException();
-
-        public string Identifier => throw new NotImplementedException();
 
         public IEnumerable<char> IntellisenseSearchCharacters => throw new NotImplementedException();
 

--- a/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/CodeEditor.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/CodeEditor/CodeEditor.cs
@@ -815,8 +815,6 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
             {
                 SyntaxHighlighting = CustomHighlightingManager.Instance.GetDefinition(LanguageService.LanguageId.ToUpper());
 
-                LanguageServiceName = LanguageService.Title;
-
                 LanguageService.RegisterSourceFile(DocumentAccessor);
 
                 _diagnosticMarkersRenderer = new TextMarkerService(Document);
@@ -862,11 +860,6 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
                     Observable.FromEventPattern<DiagnosticsUpdatedEventArgs>(LanguageService, nameof(LanguageService.DiagnosticsUpdated)).ObserveOn(AvaloniaScheduler.Instance).Subscribe(args =>
                     LanguageService_DiagnosticsUpdated(args.Sender, args.EventArgs))
                 };
-            }
-            else
-            {
-                LanguageService = null;
-                LanguageServiceName = "Plain Text";
             }
 
             StartBackgroundWorkers();
@@ -1144,16 +1137,6 @@ namespace AvalonStudio.Controls.Standard.CodeEditor
             get { return GetValue(ColumnProperty); }
             set { SetValue(ColumnProperty, value); }
         }
-
-        public static readonly StyledProperty<string> LanguageServiceNameProperty =
-            AvaloniaProperty.Register<CodeEditor, string>(nameof(LanguageServiceName), defaultBindingMode: BindingMode.TwoWay);
-
-        public string LanguageServiceName
-        {
-            get { return GetValue(LanguageServiceNameProperty); }
-            set { SetValue(LanguageServiceNameProperty, value); }
-        }
-
 
         public static readonly StyledProperty<ObservableCollection<IVisualLineTransformer>> DocumentLineTransformersProperty =
             AvaloniaProperty.Register<CodeEditor, ObservableCollection<IVisualLineTransformer>>(nameof(DocumentLineTransformers), new ObservableCollection<IVisualLineTransformer>());

--- a/AvalonStudio/AvalonStudio.Extensibility/Languages/ILanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Languages/ILanguageService.cs
@@ -40,19 +40,9 @@ namespace AvalonStudio.Languages
         IIndentationStrategy IndentationStrategy { get; }
 
         /// <summary>
-        ///     A description of the language supported by the service, i.e. C/C++
-        /// </summary>
-        string Title { get; }
-
-        /// <summary>
         /// A file path compatible name for the language, i.e. cs, cpp, ts, css, go, vb, fsharp
         /// </summary>
         string LanguageId { get; }
-
-        /// <summary>
-        /// An identifier compatible with Dot CLI language identifiers i.e. C#, F#, VB, etc
-        /// </summary>
-        string Identifier { get; }
 
         /// <summary>
         /// Dictionary of functions for transforming snippet variables. Key is function name, the arugment is the string to transform.

--- a/AvalonStudio/AvalonStudio.LanguageSupport.TypeScript/LanguageService/TypeScriptLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.LanguageSupport.TypeScript/LanguageService/TypeScriptLanguageService.cs
@@ -97,15 +97,11 @@ namespace AvalonStudio.LanguageSupport.TypeScript.LanguageService
 
         public IIndentationStrategy IndentationStrategy { get; }
 
-        public string Title => "TypeScript";
-
         public IDictionary<string, Func<string, string>> SnippetCodeGenerators => null;
 
         public IDictionary<string, Func<int, int, int, string>> SnippetDynamicVariables => null;
 
         public string LanguageId => "ts";
-
-        public string Identifier => "TS";
 
         public IObservable<SyntaxHighlightDataList> AdditionalHighlightingData => throw new NotImplementedException();
 

--- a/AvalonStudio/AvalonStudio.Languages.CPlusPlus/CPlusPlusLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.CPlusPlus/CPlusPlusLanguageService.cs
@@ -82,11 +82,6 @@ namespace AvalonStudio.Languages.CPlusPlus
             _snippetDynamicVars.Add("ClassName", (offset, line, column) => null);
         }
 
-        public string Title
-        {
-            get { return "C/C++"; }
-        }
-
         public IIndentationStrategy IndentationStrategy { get; private set; }
 
         public bool CanTriggerIntellisense(char currentChar, char previousChar)
@@ -130,8 +125,6 @@ namespace AvalonStudio.Languages.CPlusPlus
         public IDictionary<string, Func<int, int, int, string>> SnippetDynamicVariables => _snippetDynamicVars;
 
         public string LanguageId => "cpp";
-
-        public string Identifier => "C++";
 
         public IEnumerable<ICodeEditorInputHelper> InputHelpers => null;
 

--- a/AvalonStudio/AvalonStudio.Languages.CSharp/CSharpLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.CSharp/CSharpLanguageService.cs
@@ -100,21 +100,11 @@ namespace AvalonStudio.Languages.CSharp
             get; private set;
         }
 
-        public string Title
-        {
-            get
-            {
-                return "C#";
-            }
-        }
-
         public IDictionary<string, Func<string, string>> SnippetCodeGenerators => _snippetCodeGenerators;
 
         public IDictionary<string, Func<int, int, int, string>> SnippetDynamicVariables => _snippetDynamicVars;
 
         public string LanguageId => "cs";
-
-        public string Identifier => "C#";
 
         public IObservable<SyntaxHighlightDataList> AdditionalHighlightingData { get; } = new Subject<SyntaxHighlightDataList>();
 

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XamlLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XamlLanguageService.cs
@@ -1,22 +1,18 @@
 ﻿using Avalonia.Ide.CompletionEngine;
 using Avalonia.Ide.CompletionEngine.AssemblyMetadata;
 using Avalonia.Ide.CompletionEngine.SrmMetadataProvider;
+using Avalonia.Threading;
 using AvalonStudio.Documents;
 using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
-using Avalonia.Threading;
 
 namespace AvalonStudio.Languages.Xaml
 {
     [ExportLanguageService(ContentCapabilities.Xaml)]
     internal class XamlLanguageService : XmlLanguageService
     {
-        public override string Title => "XAML";
-
         public override string LanguageId => "xaml";
-
-        public override string Identifier => "XAML";
 
         public override bool CanHandle(IEditor editor)
         {

--- a/AvalonStudio/AvalonStudio.Languages.Xaml/XmlLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.Xaml/XmlLanguageService.cs
@@ -26,8 +26,6 @@ namespace AvalonStudio.Languages.Xaml
 
         public IIndentationStrategy IndentationStrategy { get; } = new XamlIndentationStrategy();
 
-        public virtual string Title => "XML";
-
         public virtual string LanguageId => "xml";
 
         public IEnumerable<ICodeEditorInputHelper> InputHelpers => s_InputHelpers;
@@ -45,8 +43,6 @@ namespace AvalonStudio.Languages.Xaml
         {
             ',', '.', ':', ';', '-', ' ', '(', ')', '[', ']', '<', '>', '=', '+', '*', '/', '%', '|', '&', '!', '^'
         };
-
-        public virtual string Identifier => "XML";        
 
         public IObservable<SyntaxHighlightDataList> AdditionalHighlightingData => throw new NotImplementedException();
 


### PR DESCRIPTION
## Changes
- Removed `Title` and `Identifier` from `ILanguageService` and implementations.
- Removed the `LanguageServiceName` property from `CodeEditor`.