### PR TITLE
Feature/jw.semantic versioning

### DIFF
--- a/AvalonStudio/AvalonStudio.Controls.Standard/AboutScreen/AboutDialogView.paml
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/AboutScreen/AboutDialogView.paml
@@ -17,7 +17,7 @@
         </StackPanel>
 	<StackPanel Orientation="Horizontal" Gap="4">
 	  <TextBlock Text="Descriptive Version:" />
-          <TextBlock Text="{Binding DescriptiveVersion}" />
+	  <TextBox BorderThickness="0" Text="{Binding DescriptiveVersion, Mode=OneWay}" IsReadOnly="True"/>
 	</StackPanel>
         <StackPanel Orientation="Horizontal" Gap="4">
           <TextBlock Text="Platform:" />

--- a/AvalonStudio/AvalonStudio.Controls.Standard/AboutScreen/AboutDialogView.paml
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/AboutScreen/AboutDialogView.paml
@@ -15,6 +15,10 @@
           <TextBlock Text="Version:" />
           <TextBlock Text="{Binding Version}" />
         </StackPanel>
+	<StackPanel Orientation="Horizontal" Gap="4">
+	  <TextBlock Text="Descriptive Version:" />
+          <TextBlock Text="{Binding DescriptiveVersion}" />
+	</StackPanel>
         <StackPanel Orientation="Horizontal" Gap="4">
           <TextBlock Text="Platform:" />
           <TextBlock Text="{Binding PlatformString}" />

--- a/AvalonStudio/AvalonStudio.Controls.Standard/AboutScreen/AboutDialogViewModel.cs
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/AboutScreen/AboutDialogViewModel.cs
@@ -19,6 +19,7 @@ namespace AvalonStudio.Controls.Standard.AboutScreen
         public override ReactiveCommand OKCommand { get; protected set; }
 
         public string Version => FileVersionInfo.GetVersionInfo(Assembly.GetEntryAssembly().Location).FileVersion;
+	public string DescriptiveVersion => ThisAssembly.Git.Tag + (ThisAssembly.Git.IsDirty ? "-dirty": "");
 
         public string PlatformString { get; }
     }

--- a/AvalonStudio/AvalonStudio.Controls.Standard/AvalonStudio.Controls.Standard.csproj
+++ b/AvalonStudio/AvalonStudio.Controls.Standard/AvalonStudio.Controls.Standard.csproj
@@ -22,6 +22,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Avalonia" Version="0.6.2-build4628-beta" />
+    <PackageReference Include="GitInfo" Version="2.0.10" />
     <PackageReference Include="System.Composition" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup>

--- a/AvalonStudio/AvalonStudio/AvalonStudio.csproj
+++ b/AvalonStudio/AvalonStudio/AvalonStudio.csproj
@@ -7,11 +7,9 @@
     <PreserveCompilationContext>true</PreserveCompilationContext>
     <RuntimeIdentifiers>win7-x64;ubuntu.14.04-x64;debian.8-x64;osx.10.12-x64</RuntimeIdentifiers>
     <ApplicationIcon>Assets\icon.ico</ApplicationIcon>
-    <Version>0.4.3</Version>
-    <AssemblyVersion>0.4.3.0</AssemblyVersion>
-    <FileVersion>0.4.3.0</FileVersion>
     <NoWarn>NU1701</NoWarn>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
   <ItemGroup>

--- a/AvalonStudio/AvalonStudio/AvalonStudio.csproj
+++ b/AvalonStudio/AvalonStudio/AvalonStudio.csproj
@@ -24,6 +24,7 @@
     <PackageReference Include="Avalonia.Skia.Linux.Natives" Version="1.57.1.4" />
     <PackageReference Include="Avalonia.Xaml.Behaviors" Version="0.6.1" />
     <PackageReference Include="Avalonia.Xaml.Interactions.Custom" Version="0.6.1" />
+    <PackageReference Include="GitInfo" Version="2.0.10" />
     <PackageReference Include="Mabiavalon.DockNC" Version="0.0.1-build110-alpha" />
     <PackageReference Include="reactiveui" Version="8.0.0-alpha0089" />
     <PackageReference Include="System.Composition" Version="1.1.0" />

--- a/AvalonStudio/AvalonStudio/GlobalAssemblyInfo.cs
+++ b/AvalonStudio/AvalonStudio/GlobalAssemblyInfo.cs
@@ -1,0 +1,42 @@
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following
+// // set of attributes. Change these attribute values to modify the information
+// // associated with an assembly.
+[assembly: AssemblyTitle("AvalonStudio")]
+[assembly: AssemblyDescription("")]
+// [assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("VitalElement")]
+[assembly: AssemblyProduct("AvalonStudio")]
+[assembly: AssemblyCopyright("Copyright © 2018 Vital Element")]
+// [assembly: AssemblyTrademark("")]
+// [assembly: AssemblyCulture("")]
+//
+// // Setting ComVisible to false makes the types in this assembly not visible
+// // to COM components.  If you need to access a type in this assembly from
+// // COM, set the ComVisible attribute to true on that type.
+// [assembly: ComVisible(false)]
+//
+// // The following GUID is for the ID of the typelib if this project is exposed to COM
+// [assembly: Guid("1537d08c-98b8-4a9e-af02-8a162f873b82")]
+//
+// // Version information for an assembly consists of the following four values:
+// //
+// //      Major Version
+// //      Minor Version
+// //      Build Number
+// //      Revision
+// //
+// // You can specify all the values or you can default the Build and Revision Numbers
+// // by using the '*' as shown below:
+// // [assembly: AssemblyVersion("1.0.*")]
+// [assembly: AssemblyVersion("1.0.0.0")]
+// [assembly: AssemblyFileVersion("1.0.0.0")]
+//
+
+
+[assembly: AssemblyVersion (ThisAssembly.Git.BaseVersion.Major + "." + ThisAssembly.Git.BaseVersion.Minor + "." + ThisAssembly.Git.BaseVersion.Patch)]
+[assembly: AssemblyFileVersion (ThisAssembly.Git.BaseVersion.Major + "." + ThisAssembly.Git.BaseVersion.Minor + "." + ThisAssembly.Git.BaseVersion.Patch + "-" + ThisAssembly.Git.Commits)]
+


### PR DESCRIPTION
Added semantic version using Git Information.
AssemblyVersion is used by dotnet to ensure compatibility, so this should really only depend on Maj.Min
