### PR TITLE
Prevents resizing main windows too much

### DIFF
--- a/AvalonStudio/AvalonStudio/MainWindow.paml
+++ b/AvalonStudio/AvalonStudio/MainWindow.paml
@@ -11,6 +11,7 @@
                       Title="AvalonStudio" BorderThickness="1" BorderBrush="{DynamicResource AvalonBorderBrush}"
                       FontFamily="{DynamicResource UiFont}" FontSize="14"
                       xmlns:cont="clr-namespace:AvalonStudio.Controls;assembly=AvalonStudio"
+                      MinHeight="200" MinWidth="200"
                       Foreground="{DynamicResource ThemeForegroundBrush}" WindowState="Maximized">
   <Controls:MetroWindow.TitleBarContent>
   </Controls:MetroWindow.TitleBarContent>


### PR DESCRIPTION
This PR is for issue https://github.com/VitalElement/AvalonStudio/issues/667
Height 200 and Width 200 are arbitrary values but they are probably better than keeping the default values. If this solution is not correct or it is not acceptable then, please let me know how.

![image](https://user-images.githubusercontent.com/127973/40997989-d13483d8-68dc-11e8-90f1-577b7457fb8c.png)
![image](https://user-images.githubusercontent.com/127973/40998015-e850e962-68dc-11e8-8028-59a70baeac84.png)
