### PR TITLE
Menu separator w/o margin

### DIFF
--- a/AvalonStudio/AvalonStudio.Extensibility/MainMenu/Views/MainMenuView.paml
+++ b/AvalonStudio/AvalonStudio.Extensibility/MainMenu/Views/MainMenuView.paml
@@ -1,6 +1,12 @@
 ﻿<UserControl xmlns="https://github.com/avaloniaui"
              xmlns:mod="clr-namespace:AvalonStudio.Menus.Models;assembly=AvalonStudio.Extensibility">
 
+  <UserControl.Styles>
+    <Style Selector="Separator">
+      <Setter Property="Margin" Value="0"/>
+    </Style>
+  </UserControl.Styles>
+
   <Menu Items="{Binding Items}">
     <Menu.Styles>
       <Style Selector="MenuItem">
@@ -17,8 +23,8 @@
       </Style>
     </Menu.Styles>
     <Menu.DataTemplates>
-      <DataTemplate DataType="mod:MenuItemSeparatorModel">        
-          <Separator />        
+      <DataTemplate DataType="mod:MenuItemSeparatorModel">
+          <Separator />
       </DataTemplate>
     </Menu.DataTemplates>
   </Menu>


### PR DESCRIPTION
Fixes issue https://github.com/VitalElement/AvalonStudio/issues/668 setting Margin=0 for Separator element. 

### Before
![image](https://user-images.githubusercontent.com/127973/41059710-b3ef97fa-69a3-11e8-90ee-19edae33db48.png)

### After
![screenshot from 2018-06-06 16-00-01](https://user-images.githubusercontent.com/127973/41059630-87bcfbe6-69a3-11e8-9fa7-2fb59361386f.png)


