### PR TITLE
Adds tooltips to windows upper right buttons

### DIFF
--- a/AvalonStudio/AvalonStudio/Controls/MetroWindow.cs
+++ b/AvalonStudio/AvalonStudio/Controls/MetroWindow.cs
@@ -113,10 +113,12 @@ namespace AvalonStudio.Controls
             {
                 case WindowState.Maximized:
                     WindowState = WindowState.Normal;
+                    ToolTip.SetTip(restoreButton, "Maximize");
                     break;
 
                 case WindowState.Normal:
                     WindowState = WindowState.Maximized;
+                    ToolTip.SetTip(restoreButton, "Restore");
                     break;
             }
         }

--- a/AvalonStudio/AvalonStudio/Controls/MetroWindow.paml
+++ b/AvalonStudio/AvalonStudio/Controls/MetroWindow.paml
@@ -28,19 +28,19 @@
                           <StyleInclude Source="resm:AvalonStudio.Controls.MetroWindowControlsTheme.paml?assembly=AvalonStudio" />
                         </Grid.Styles>
                         <StackPanel Orientation="Horizontal">
-                          <Button Background="Transparent" BorderThickness="0" Name="minimiseButton">
+                          <Button Background="Transparent" BorderThickness="0" Name="minimiseButton" ToolTip.Tip="Minimize">
                             <Panel Margin="4">
                               <Path Margin="0" Height="8" Width="8" Stretch="Uniform" UseLayoutRounding="False"  Data="M20,14H4V10H20" Fill="{DynamicResource ThemeForegroundBrush}" />
                             </Panel>
                           </Button>
 
-                          <Button Background="Transparent" BorderThickness="0" Name="restoreButton">
+                          <Button Background="Transparent" BorderThickness="0" Name="restoreButton" ToolTip.Tip="Restore">
                             <Panel Margin="4">
                               <Path Height="8" Width="8" Stretch="Uniform" UseLayoutRounding="False"  Data="M4,8H8V4H20V16H16V20H4V8M16,8V14H18V6H10V8H16M6,12V18H14V12H6Z" Fill="{DynamicResource ThemeForegroundBrush}" />
                             </Panel>
                           </Button>
 
-                          <Button Background="Transparent" BorderThickness="0" Name="closeButton">
+                          <Button Background="Transparent" BorderThickness="0" Name="closeButton" ToolTip.Tip="Close">
                             <Panel Margin="4">
                               <Path Height="8" Width="8" Stretch="Uniform" UseLayoutRounding="False"  Data="M13.46,12L19,17.54V19H17.54L12,13.46L6.46,19H5V17.54L10.54,12L5,6.46V5H6.46L12,10.54L17.54,5H19V6.46L13.46,12Z" Fill="{DynamicResource ThemeForegroundBrush}" />
                             </Panel>


### PR DESCRIPTION
Another trivial PR for adding Tool Tips to Minimize, Restore and Close upper right windows buttons suggested by @nopara73 in issue #662.

![image](https://user-images.githubusercontent.com/127973/41108863-06579f6c-6a4c-11e8-8f29-58cd9fc7ea05.png)
