### PR TITLE
README: fix instruction in run binaries step

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,6 @@ dotnet build
 ### 4. Run locally built binaries
 
 ```sh
-cd bin/Debug/netcoreapp2.1
+cd bin/Debug/netcoreapp2.2
 dotnet ./AvalonStudio.dll
 ```


### PR DESCRIPTION
The folder now seems to be named netcoreapp2.2