### PR TITLE
Adds highlighting for the 'keyword - control" roslyn type.

### DIFF
--- a/AvalonStudio/AvalonStudio.Extensibility/Editor/ColorScheme.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Editor/ColorScheme.cs
@@ -52,6 +52,7 @@ namespace AvalonStudio.Extensibility.Editor
             s_colorAccessors["struct.name"] = () => CurrentColorScheme.StructName;
             s_colorAccessors["interface"] = () => CurrentColorScheme.InterfaceType;
             s_colorAccessors["punctuation"] = () => CurrentColorScheme.Punctuation;
+            s_colorAccessors["excudedcode"] = () => CurrentColorScheme.ExcludedCode;
             s_colorAccessors["type"] = () => CurrentColorScheme.Type;
             s_colorAccessors["xml.tag"] = () => CurrentColorScheme.XmlTag;
             s_colorAccessors["xml.property"] = () => CurrentColorScheme.XmlProperty;
@@ -90,6 +91,7 @@ namespace AvalonStudio.Extensibility.Editor
             EnumType = Brush.Parse("#2B91AF"),
             NumericLiteral = Brush.Parse("#000000"),
             Punctuation = Brush.Parse("#000000"),
+            ExcludedCode = Brush.Parse("#000000"),
             Type = Brush.Parse("#2B91AF"),
             StructName = Brush.Parse("#2B91AF"),
             Operator = Brush.Parse("#000000"),
@@ -125,6 +127,7 @@ namespace AvalonStudio.Extensibility.Editor
             EnumType = Brush.Parse("#B5CEA8"),
             NumericLiteral = Brush.Parse("#B5CEA8"),
             Punctuation = Brush.Parse("#808080"),
+            ExcludedCode = Brush.Parse("#808080"),
             Type = Brush.Parse("#4EC9B0"),
             StructName = Brush.Parse("#4EC9B0"),
             Operator = Brush.Parse("#B4B4B4"),
@@ -160,6 +163,7 @@ namespace AvalonStudio.Extensibility.Editor
             EnumType = Brush.Parse("#2B91AF"),
             NumericLiteral = Brush.Parse("#000000"),
             Punctuation = Brush.Parse("#000000"),
+            ExcludedCode = Brush.Parse("#000000"),
             Type = Brush.Parse("#3465a4"),
             StructName = Brush.Parse("#3465a4"),
             Operator = Brush.Parse("#000000"),
@@ -195,6 +199,7 @@ namespace AvalonStudio.Extensibility.Editor
             EnumType = Brush.Parse("#b58900"),
             NumericLiteral = Brush.Parse("#2aa198"),
             Punctuation = Brush.Parse("#839496"),
+            ExcludedCode = Brush.Parse("#839496"),
             Type = Brush.Parse("#b58900"),
             StructName = Brush.Parse("Red"),
             Operator = Brush.Parse("Red")
@@ -223,6 +228,7 @@ namespace AvalonStudio.Extensibility.Editor
             EnumType = Brush.Parse("#b58900"),
             NumericLiteral = Brush.Parse("#2aa198"),
             Punctuation = Brush.Parse("#839496"),
+            ExcludedCode = Brush.Parse("#839496"),
             Type = Brush.Parse("#b58900"),
             StructName = Brush.Parse("Red"),
             Operator = Brush.Parse("Red"),
@@ -356,6 +362,9 @@ namespace AvalonStudio.Extensibility.Editor
 
         [JsonProperty(PropertyName = "editor.type")]
         public IBrush Type { get; set; }
+
+        [JsonProperty(PropertyName = "editor.excludedcode")]
+        public IBrush ExcludedCode { get; set; }
 
         [JsonProperty(PropertyName = "editor.xml.tag")]
         public IBrush XmlTag { get; set; }

--- a/AvalonStudio/AvalonStudio.Extensibility/Editor/ColorScheme.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Editor/ColorScheme.cs
@@ -40,6 +40,7 @@ namespace AvalonStudio.Extensibility.Editor
             s_colorAccessors["text"] = () => CurrentColorScheme.Text;
             s_colorAccessors["comment"] = () => CurrentColorScheme.Comment;
             s_colorAccessors["delegate.name"] = () => CurrentColorScheme.DelegateName;
+            s_colorAccessors["keyword.control"] = () => CurrentColorScheme.ControlKeyword;
             s_colorAccessors["keyword"] = () => CurrentColorScheme.Keyword;
             s_colorAccessors["literal"] = () => CurrentColorScheme.Literal;
             s_colorAccessors["identifier"] = () => CurrentColorScheme.Identifier;
@@ -79,6 +80,7 @@ namespace AvalonStudio.Extensibility.Editor
             InfoDiagnostic = Brush.Parse("#0019FF"),
             StyleDiagnostic = Brush.Parse("#D4D4D4"),
             Comment = Brush.Parse("#008000"),
+            ControlKeyword = Brush.Parse("#0000FF"),
             Keyword = Brush.Parse("#0000FF"),
             Literal = Brush.Parse("#A31515"),
             Identifier = Brush.Parse("#000000"),
@@ -113,6 +115,7 @@ namespace AvalonStudio.Extensibility.Editor
             InfoDiagnostic = Brush.Parse("#0019FF"),
             StyleDiagnostic = Brush.Parse("#D4D4D4"),
             Comment = Brush.Parse("#57A64A"),
+            ControlKeyword = Brush.Parse("#569CD6"),
             Keyword = Brush.Parse("#569CD6"),
             Literal = Brush.Parse("#D69D85"),
             Identifier = Brush.Parse("#C8C8C8"),
@@ -147,6 +150,7 @@ namespace AvalonStudio.Extensibility.Editor
             InfoDiagnostic = Brush.Parse("#0019FF"),
             StyleDiagnostic = Brush.Parse("#D4D4D4"),
             Comment = Brush.Parse("#888a85"),
+            ControlKeyword = Brush.Parse("#009695"),
             Keyword = Brush.Parse("#009695"),
             Literal = Brush.Parse("#db7100"),
             Identifier = Brush.Parse("#000000"),
@@ -181,6 +185,7 @@ namespace AvalonStudio.Extensibility.Editor
             InfoDiagnostic = Brush.Parse("#0019FF"),
             StyleDiagnostic = Brush.Parse("#D4D4D4"),
             Comment = Brush.Parse("#586e75"),
+            ControlKeyword = Brush.Parse("#859900"),
             Keyword = Brush.Parse("#859900"),
             Literal = Brush.Parse("#2aa198"),
             Identifier = Brush.Parse("#839496"),
@@ -208,6 +213,7 @@ namespace AvalonStudio.Extensibility.Editor
             InfoDiagnostic = Brush.Parse("#0019FF"),
             StyleDiagnostic = Brush.Parse("#D4D4D4"),
             Comment = Brush.Parse("#93a1a1"),
+            ControlKeyword = Brush.Parse("#859900"),
             Keyword = Brush.Parse("#859900"),
             Literal = Brush.Parse("#2aa198"),
             Identifier = Brush.Parse("#839496"),
@@ -314,6 +320,9 @@ namespace AvalonStudio.Extensibility.Editor
 
         [JsonProperty(PropertyName = "editor.keyword")]
         public IBrush Keyword { get; set; }
+
+        [JsonProperty(PropertyName = "editor.keyword.control")]
+        public IBrush ControlKeyword { get; set; }
 
         [JsonProperty(PropertyName = "editor.literal")]
         public IBrush Literal { get; set; }

--- a/AvalonStudio/AvalonStudio.Extensibility/Languages/SyntaxHighlightingData.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Languages/SyntaxHighlightingData.cs
@@ -23,6 +23,7 @@ namespace AvalonStudio.Languages
         PreProcessor,
         PreProcessorText,
         Operator,
+        ExcludedCode,
         Unnecessary
     }
 

--- a/AvalonStudio/AvalonStudio.Extensibility/Languages/SyntaxHighlightingData.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Languages/SyntaxHighlightingData.cs
@@ -8,6 +8,7 @@ namespace AvalonStudio.Languages
         None,
         CallExpression,
         Punctuation,
+        ControlKeyword,
         Keyword,
         Identifier,
         Literal,

--- a/AvalonStudio/AvalonStudio.Extensibility/Languages/TextColoringTransformer.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Languages/TextColoringTransformer.cs
@@ -185,6 +185,10 @@ namespace AvalonStudio.Languages
                     result = colorScheme.StructName;
                     break;
 
+                case HighlightType.ExcludedCode:
+                    result = colorScheme.ExcludedCode;
+                    break;
+
                 default:
                     result = Brushes.Red;
                     break;

--- a/AvalonStudio/AvalonStudio.Extensibility/Languages/TextColoringTransformer.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Languages/TextColoringTransformer.cs
@@ -141,6 +141,10 @@ namespace AvalonStudio.Languages
                     result = colorScheme.Identifier;
                     break;
 
+                case HighlightType.ControlKeyword:
+                    result = colorScheme.ControlKeyword;
+                    break;
+
                 case HighlightType.Keyword:
                     result = colorScheme.Keyword;
                     break;

--- a/AvalonStudio/AvalonStudio.Extensibility/Languages/TextColoringTransformer.cs
+++ b/AvalonStudio/AvalonStudio.Extensibility/Languages/TextColoringTransformer.cs
@@ -185,6 +185,14 @@ namespace AvalonStudio.Languages
                     result = colorScheme.StructName;
                     break;
 
+                case HighlightType.PreProcessor:
+                    result = colorScheme.Punctuation;
+                    break;
+
+                case HighlightType.PreProcessorText:
+                    result = colorScheme.Text;
+                    break;
+
                 case HighlightType.ExcludedCode:
                     result = colorScheme.ExcludedCode;
                     break;

--- a/AvalonStudio/AvalonStudio.Languages.CSharp/CSharpLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.CSharp/CSharpLanguageService.cs
@@ -773,7 +773,7 @@ namespace AvalonStudio.Languages.CSharp
                     break;
 
                 case "excluded code":
-                    result = HighlightType.None;
+                    result = HighlightType.ExcludedCode;
                     break;
 
                 default:
@@ -839,6 +839,7 @@ namespace AvalonStudio.Languages.CSharp
                     result = Format((uint)startOffset, (uint)(endOffset - startOffset), caret);
                 }
             }
+
             return result;
         }
 

--- a/AvalonStudio/AvalonStudio.Languages.CSharp/CSharpLanguageService.cs
+++ b/AvalonStudio/AvalonStudio.Languages.CSharp/CSharpLanguageService.cs
@@ -720,6 +720,10 @@ namespace AvalonStudio.Languages.CSharp
                     result = HighlightType.Keyword;
                     break;
 
+                case "keyword - control":
+                    result = HighlightType.ControlKeyword;
+                    break;
+
                 case "identifier":
                     result = HighlightType.Identifier;
                     break;


### PR DESCRIPTION
This adds highlighting for keywords that cause a change in control flow and allows it to be configured separately from normal keywords.

This fixes issues where certain keywords like `throw` `yield` `return` `case` `foreach` `try` `catch` `else` `if` `for` `goto` (among others) might fail to highlight in certain conditions. 